### PR TITLE
Traptor will only enrich actual tweets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,4 @@ var/
 
 dump.rdb
 .coverage*
+htmlcov/*

--- a/tests/data/other_tweet_messages.json
+++ b/tests/data/other_tweet_messages.json
@@ -6,62 +6,46 @@
       "user_id":3,
       "user_id_str":"3"
     }
-  }
-},
-{
+  },
   "warning":{
     "code":"FALLING_BEHIND",
     "message":"Your connection is falling behind and messages are being queued for delivery to you. Your queue is now over 60% full. You will be disconnected when the queue is full.",
     "percent_full": 60
-  }
-},
-{
+  },
   "scrub_geo":{
     "user_id":14090452,
     "user_id_str":"14090452",
     "up_to_status_id":23260136625,
     "up_to_status_id_str":"23260136625"
-  }
-},
-{
+  },
   "limit":{
     "track":1234
-  }
-},
-{
+  },
   "status_withheld":{
       "id":1234567890,
       "user_id":123456,
       "withheld_in_countries":["DE", "AR"]
-  }
-},
-{
+  },
   "user_withheld":{
     "id":123456,
     "withheld_in_countries":["DE","AR"]
-  }
-},
-{
+  },
   "disconnect":{
     "code": 4,
     "stream_name":"",
     "reason":""
-  }
-},
-{
+  },
   "warning":{
     "code":"FALLING_BEHIND",
     "message":"Your connection is falling behind and messages are being queued for delivery to you. Your queue is now over 60% full. You will be disconnected when the queue is full.",
     "percent_full": 60
-  }
-},
-{
+  },
     "created_at": "Tue Aug 06 02:23:21 +0000 2013",
     "source": {
-         ...
+         "some_source": "blah blah"
     },
     "target": {
-      ...
+      "some_target": "blah blah"
     },
     "event": "user_update"
 }

--- a/tests/test_traptor_offline.py
+++ b/tests/test_traptor_offline.py
@@ -13,7 +13,7 @@ from traptor.traptor import Traptor, MyBirdyClient
 from scripts.rule_extract import RulesToRedis
 from scutils.log_factory import LogObject
 
-HOST_FOR_TESTING = 'scdev'
+HOST_FOR_TESTING = 'localhost'
 
 
 @pytest.fixture()

--- a/tests/test_traptor_offline.py
+++ b/tests/test_traptor_offline.py
@@ -13,6 +13,8 @@ from traptor.traptor import Traptor, MyBirdyClient
 from scripts.rule_extract import RulesToRedis
 from scutils.log_factory import LogObject
 
+HOST_FOR_TESTING = 'scdev'
+
 
 @pytest.fixture()
 def redis_rules(request):
@@ -24,7 +26,7 @@ def redis_rules(request):
     with open('tests/data/locations_rules.json') as f:
         locations_rules = [json.loads(line) for line in f]
 
-    conn = StrictRedis(host='localhost', port=6379, db=5)
+    conn = StrictRedis(host=HOST_FOR_TESTING, port=6379, db=5)
     conn.flushdb()
 
     rc = RulesToRedis(conn)
@@ -43,7 +45,7 @@ def redis_rules(request):
 @pytest.fixture()
 def pubsub_conn():
     """Create a connection for the Redis PubSub."""
-    p_conn = StrictRedis(host='localhost', port=6379, db=5)
+    p_conn = StrictRedis(host=HOST_FOR_TESTING, port=6379, db=5)
     return p_conn
 
 
@@ -89,6 +91,15 @@ def tweets(request, traptor):
         loaded_tweet = json.load(f)
 
     return loaded_tweet
+    
+
+@pytest.fixture
+def non_tweet_stream_messages(request, traptor):
+    """Create a list of non-tweet stream messages."""
+    with open('tests/data/other_tweet_messages.json') as f:
+        stream_messages = json.load(f)
+
+    return stream_messages
 
 
 @pytest.fixture
@@ -197,23 +208,22 @@ class TestTraptor(object):
         traptor.birdy_stream = MagicMock(return_value=tweets)
         traptor.birdy_stream.stream = traptor.birdy_stream
 
-        _data = traptor.birdy_stream.stream()
-        data = traptor._fix_tweet_object(_data)
-        enriched_data = traptor._find_rule_matches(data)
+        tweet = traptor.birdy_stream.stream()
+        enriched_data = traptor._enrich_tweet(tweet)
 
         if traptor.traptor_type == 'track':
 
-            assert data['traptor']['created_at_iso'] == '2016-02-22T01:34:53+00:00'
+            assert enriched_data['traptor']['created_at_iso'] == '2016-02-22T01:34:53+00:00'
             assert enriched_data['traptor']['rule_tag'] == 'test'
             assert enriched_data['traptor']['rule_value'] == 'happy'
 
         if traptor.traptor_type == 'follow':
-            assert data['traptor']['created_at_iso'] == '2016-02-20T03:52:59+00:00'
+            assert enriched_data['traptor']['created_at_iso'] == '2016-02-20T03:52:59+00:00'
             assert enriched_data['traptor']['rule_tag'] == 'test'
             assert enriched_data['traptor']['rule_value'] == '17919972'
 
         if traptor.traptor_type == 'locations':
-            assert data['traptor']['created_at_iso'] == '2016-02-23T02:02:54+00:00'
+            assert enriched_data['traptor']['created_at_iso'] == '2016-02-23T02:02:54+00:00'
 
     def test_ensure_heartbeat_message_is_produced(self, traptor):
         """Ensure Traptor can produce heartbeat messages."""
@@ -236,3 +246,11 @@ class TestTraptor(object):
             traptor.heartbeat_conn.setex.side_effect = ConnectionError
 
             traptor._add_heartbeat_message_to_redis(traptor.heartbeat_conn)
+
+    def test_ensure_traptor_only_enriches_tweets(self, traptor, non_tweet_stream_messages):
+        """Ensure Traptor only performs rule matching on tweets."""
+        traptor._setup()
+        
+        for message in non_tweet_stream_messages:
+            enriched_data = traptor._enrich_tweet(message)
+            assert enriched_data == message

--- a/traptor/version.py
+++ b/traptor/version.py
@@ -1,2 +1,2 @@
-__version__ = '1.2.1'
+__version__ = '1.2.2'
 VERSION = tuple(int(x) for x in __version__.split('.'))


### PR DESCRIPTION
Twitter sends 8 non-tweet messages via the stream. This update makes it
so that Traptor only enriches tweets. It also brings our code coverage
up to 63%.