### PR TITLE
Pulse 2722 - Idle Traptor when no rules are assigned

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,6 @@ var/
 dump.rdb
 .coverage*
 htmlcov/*
+
+# PyCharm Files
+.idea/*

--- a/tests/test_traptor_offline.py
+++ b/tests/test_traptor_offline.py
@@ -14,7 +14,7 @@ from traptor.traptor import Traptor, MyBirdyClient
 from scripts.rule_extract import RulesToRedis
 from scutils.log_factory import LogObject
 
-HOST_FOR_TESTING = 'localhost'
+HOST_FOR_TESTING = 'scdev'
 
 
 @pytest.fixture()
@@ -324,3 +324,8 @@ class TestTraptor(object):
             print(message)
             enriched_data = traptor._enrich_tweet(message)
             assert enriched_data == message
+
+    def test_ensure_traptor_stays_alive_until_rules_are_found(self, traptor):
+        traptor._setup()
+
+        traptor.redis_rules = [rule for rule in traptor._get_redis_rules()]

--- a/tests/test_traptor_offline.py
+++ b/tests/test_traptor_offline.py
@@ -14,7 +14,7 @@ from traptor.traptor import Traptor, MyBirdyClient
 from scripts.rule_extract import RulesToRedis
 from scutils.log_factory import LogObject
 
-HOST_FOR_TESTING = 'scdev'
+HOST_FOR_TESTING = 'localhost'
 
 
 @pytest.fixture()
@@ -329,3 +329,4 @@ class TestTraptor(object):
         traptor._setup()
 
         traptor.redis_rules = [rule for rule in traptor._get_redis_rules()]
+

--- a/tests/test_traptor_offline.py
+++ b/tests/test_traptor_offline.py
@@ -78,6 +78,7 @@ def traptor(request, redis_rules, pubsub_conn, heartbeat_conn, traptor_notify_ch
                                kafka_topic='traptor_test',
                                kafka_enabled=False,
                                log_level='INFO',
+                               rule_check_interval=2,
                                test=True,
                                traptor_notify_channel=traptor_notify_channel
                                )
@@ -327,6 +328,13 @@ class TestTraptor(object):
 
     def test_ensure_traptor_stays_alive_until_rules_are_found(self, traptor):
         traptor._setup()
+        traptor.rule_check_interval = 2
+        traptor.logger.debug = MagicMock()
 
-        traptor.redis_rules = [rule for rule in traptor._get_redis_rules()]
-        pass
+        empty_response = {}
+        good_response = {"Rule": "Fun"}
+
+        traptor._get_redis_rules = MagicMock(side_effect=[empty_response, empty_response, good_response])
+        traptor._wait_for_rules()
+
+        assert traptor.logger.debug.call_count == 2

--- a/tests/test_traptor_offline.py
+++ b/tests/test_traptor_offline.py
@@ -329,4 +329,4 @@ class TestTraptor(object):
         traptor._setup()
 
         traptor.redis_rules = [rule for rule in traptor._get_redis_rules()]
-
+        pass

--- a/traptor/settings.py
+++ b/traptor/settings.py
@@ -20,6 +20,9 @@ REDIS_PUBSUB_CHANNEL = "traptor-notify"
 # Kafka topic to write all twitter data
 KAFKA_TOPIC = "traptor"
 
+# Time to wait between checks of Redis for rules assigned to this Traptor
+RULE_CHECK_INTERVAL = 60
+
 # Your API information.  Fill this out in localsettings.py!
 APIKEYS = (
            {


### PR DESCRIPTION
Traptors are now able to idle for a configurable amount of time until rules are assigned to them in Redis. Once rules are found, the idle ceases and collection begins.

And yes, there is a test for it!