### PR TITLE
PULSE-3429: Update Docker Elasticsearch containers

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -46,7 +46,8 @@ services:
       - "2181:2181"
 
   elasticsearch:
-    image: elasticsearch:2.4.1
+    image: elasticsearch:5.0
+    command: elasticsearch -E network.host=0.0.0.0 -E discovery.zen.minimum_master_nodes=1
     ports:
       - "9200:9200"
 
@@ -69,7 +70,7 @@ services:
       - ./logs:/var/log/traptor
 
   kibana:
-    image: kibana:4.6.2
+    image: kibana:5.0
     ports:
       - "5601:5601"
     environment:


### PR DESCRIPTION
**BLUF**

Updated ES and Kibana images to version 5.0.

**Testing**

To build the new images and deploy the containers, do the following:

- Clone the repo: `git clone git@github.com:istresearch/traptor.git`
- Change into the Traptor directory: `cd traptor`
- Check out the branch: `git checkout pulse-3429`
- Create a traptor.env file from the sample: `cp traptor.env.sample traptor.env`
- Set the consumer key in _traptor.env_: CONSUMER_KEY=<twitter-consumer-key>
- Set the consumer secret in _traptor.env_: CONSUMER_SECRET=<twitter-consumer-secret>
- Set the access token in _traptor.env_: ACCESS_TOKEN=<twitter-access-token>
- Set the access token secret in _traptor.env_: ACCESS_TOKEN_SECRET=<twitter-access-token-secret>
- Login to Docker Hob: `docker login`
- Build the images and launch the containers: `docker-compose up --build -d`
- Browse the Kibana URL at http://<server_name>:5601