### PR TITLE
Pulse 3507: Add retrying functionality to all Redis and Kafka methods

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,6 @@ htmlcov/*
 # Local testing files for Docker
 build_full_environment.sh
 docker-compose.build.yml
+
+# Local environment things
+.condaauto

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,3 +14,4 @@ pytest-xdist==1.14
 raven==5.13.0
 datadog==0.14.0
 mockredispy==2.9.3
+tenacity==4.0.1

--- a/tests/test_traptor_offline.py
+++ b/tests/test_traptor_offline.py
@@ -14,7 +14,6 @@ from traptor.traptor_limit_counter import TraptorLimitCounter
 from scripts.rule_extract import RulesToRedis
 from scutils.log_factory import LogObject
 from scutils.stats_collector import RollingTimeWindow
-import scutils
 
 
 @pytest.fixture()
@@ -391,7 +390,6 @@ class TestTraptor(object):
 
             l_key = "limit:{}:{}".format(traptor.traptor_type, traptor.traptor_id)
             assert traptor.limit_counter.get_key() == l_key
-
 
     # Main Loop
 

--- a/traptor/traptor.py
+++ b/traptor/traptor.py
@@ -141,7 +141,6 @@ class Traptor(object):
 
     @retry(wait=wait_exponential(multiplier=1, max=10),
            stop=stop_after_attempt(3),
-           reraise=True,
            retry=retry_if_exception_type(KafkaUnavailableError)
            )
     def _setup_kafka(self):
@@ -166,7 +165,7 @@ class Traptor(object):
                 })
                 dd_monitoring.increment('kafka_error',
                                         tags=['error_type:kafka_unavailable'])
-                # sys.exit(3)
+                sys.exit(3)
         else:
             self.logger.info('Skipping kafka connection setup')
             self.logger.debug('Kafka_enabled setting: {}'.format(self.kafka_enabled))
@@ -221,7 +220,6 @@ class Traptor(object):
 
     @retry(wait=wait_exponential(multiplier=1, max=10),
            stop=stop_after_attempt(3),
-           reraise=True,
            retry=retry_if_exception_type(TwitterApiError)
            )
     def _create_birdy_stream(self):
@@ -246,7 +244,7 @@ class Traptor(object):
                 })
                 dd_monitoring.increment('twitter_error_occurred',
                                         tags=['error_type:twitter_api_error'])
-                # sys.exit(3)
+                sys.exit(3)
         elif self.traptor_type == 'track':
             # Try to set up a twitter stream using twitter term list
             try:
@@ -260,7 +258,7 @@ class Traptor(object):
                 })
                 dd_monitoring.increment('twitter_error_occurred',
                                         tags=['error_type:twitter_api_error'])
-                # sys.exit(3)
+                sys.exit(3)
         elif self.traptor_type == 'locations':
             # Try to set up a twitter stream using twitter term list
             try:
@@ -274,7 +272,7 @@ class Traptor(object):
                 })
                 dd_monitoring.increment('twitter_error_occurred',
                                         tags=['error_type:twitter_api_error'])
-                # sys.exit(3)
+                sys.exit(3)
         else:
             self.logger.critical('Caught error creating birdy stream for Traptor type that does not exist', extra ={
                 'error_type': 'NotImplementedError',
@@ -282,7 +280,7 @@ class Traptor(object):
             })
             dd_monitoring.increment('traptor_error_occurred',
                                     tags=['error_type:not_implemented_error'])
-            # sys.exit(3)
+            sys.exit(3)
 
     def _make_twitter_rules(self, rules):
         """ Convert the rules from redis into a format compatible with the
@@ -928,7 +926,7 @@ class Traptor(object):
             future = self.kafka_conn.send(self.kafka_topic, enriched_data)
             future.add_callback(self.kafka_success_callback, tweet)
             future.add_errback(self.kafka_failure_callback)
-        except KafkaUnavailableError:
+        except Exception:
             self.logger.error("Caught exception adding Twitter message to Kafka", extra={
                 'ex': traceback.format_exc()
             })

--- a/traptor/traptor.py
+++ b/traptor/traptor.py
@@ -154,15 +154,12 @@ class Traptor(object):
                                         buffer_memory=4 * 1024 * 1024)
 
     def _setup_kafka(self):
-        """ Set up a Kafka connection.
-
-            Creates ``self.kafka_conn`` if it can reach the kafka brokers.
-        """
+        """ Set up a Kafka connection."""
         if self.kafka_enabled == 'true':
             self.logger.info('Setting up kafka connection')
             try:
                 self._create_kafka_producer()
-            except KafkaUnavailableError as e:
+            except:
                 self.logger.critical("Caught Kafka Unavailable Error", extra={
                     'error_type': 'KafkaUnavailableError',
                     'ex': traceback.format_exc()

--- a/traptor/traptor.py
+++ b/traptor/traptor.py
@@ -139,6 +139,11 @@ class Traptor(object):
                                         self.apikeys['ACCESS_TOKEN_SECRET']
                                         )
 
+    @retry(wait=wait_exponential(multiplier=1, max=10),
+           stop=stop_after_attempt(3),
+           reraise=True,
+           retry=retry_if_exception_type(KafkaUnavailableError)
+           )
     def _setup_kafka(self):
         """ Set up a Kafka connection.
 
@@ -161,7 +166,7 @@ class Traptor(object):
                 })
                 dd_monitoring.increment('kafka_error',
                                         tags=['error_type:kafka_unavailable'])
-                sys.exit(3)
+                # sys.exit(3)
         else:
             self.logger.info('Skipping kafka connection setup')
             self.logger.debug('Kafka_enabled setting: {}'.format(self.kafka_enabled))
@@ -214,6 +219,11 @@ class Traptor(object):
         # Create the locations_rule dict if this is a locations traptor
         self.locations_rule = {}
 
+    @retry(wait=wait_exponential(multiplier=1, max=10),
+           stop=stop_after_attempt(3),
+           reraise=True,
+           retry=retry_if_exception_type(TwitterApiError)
+           )
     def _create_birdy_stream(self):
         """ Create a birdy twitter stream.
             If there is a TwitterApiError it will exit with status code 3.
@@ -236,7 +246,7 @@ class Traptor(object):
                 })
                 dd_monitoring.increment('twitter_error_occurred',
                                         tags=['error_type:twitter_api_error'])
-                sys.exit(3)
+                # sys.exit(3)
         elif self.traptor_type == 'track':
             # Try to set up a twitter stream using twitter term list
             try:
@@ -250,7 +260,7 @@ class Traptor(object):
                 })
                 dd_monitoring.increment('twitter_error_occurred',
                                         tags=['error_type:twitter_api_error'])
-                sys.exit(3)
+                # sys.exit(3)
         elif self.traptor_type == 'locations':
             # Try to set up a twitter stream using twitter term list
             try:
@@ -264,7 +274,7 @@ class Traptor(object):
                 })
                 dd_monitoring.increment('twitter_error_occurred',
                                         tags=['error_type:twitter_api_error'])
-                sys.exit(3)
+                # sys.exit(3)
         else:
             self.logger.critical('Caught error creating birdy stream for Traptor type that does not exist', extra ={
                 'error_type': 'NotImplementedError',
@@ -272,7 +282,7 @@ class Traptor(object):
             })
             dd_monitoring.increment('traptor_error_occurred',
                                     tags=['error_type:not_implemented_error'])
-            sys.exit(3)
+            # sys.exit(3)
 
     def _make_twitter_rules(self, rules):
         """ Convert the rules from redis into a format compatible with the
@@ -718,7 +728,6 @@ class Traptor(object):
             })
             dd_monitoring.increment('redis_error',
                                     tags=['error_type:connection_error'])
-            sys.exit(3)  # Special error code to track known failures
 
     @staticmethod
     def _tweet_time_to_iso(tweet_time):

--- a/traptor/traptor.py
+++ b/traptor/traptor.py
@@ -24,7 +24,8 @@ from traptor_limit_counter import TraptorLimitCounter
 
 import logging
 
-logging.basicConfig(level='INFO')
+FORMAT = '%(asctime)-15s %(message)s'
+logging.basicConfig(level='INFO', format=FORMAT)
 
 # Override the default JSONobject
 class MyBirdyClient(StreamClient):
@@ -273,7 +274,7 @@ class Traptor(object):
         elif self.traptor_type == 'track':
             # Try to set up a twitter stream using twitter term list
             try:
-                self._create_twitter_follow_stream()
+                self._create_twitter_track_stream()
             except TwitterApiError as e:
                 self.logger.critical("Caught Twitter Api Error", extra={
                     'error_type': 'TwitterAPIError',


### PR DESCRIPTION
Added retrying functionality to all functions connecting to and using Redis and Kafka. Used the tenacity library.

Successfully running in the development environment.

**Testing**

Get the code

- `git clone git@github.com:istresearch/traptor.git`
- `git checkout pulse-3507-retries`

Set up your environment

- Create and activate a virtual environment (venv or Anaconda)
- Rename `traptor.env.sample` to `traptor.env` and fill in all fields. Some defaults are provided.
- Install the requirements: pip install -r requirements.txt

Run the tests

- In the root directory: python -m pytest -vv --cache-clear --cov=traptor --cov-report html

All tests should pass.