### PR TITLE
PULSE-3432: Update Integration Tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,6 @@ docker-compose.build.yml
 
 # Local environment things
 .condaauto
+
+# VS Code
+/.vscode

--- a/tests/traptor_integration_tests.py
+++ b/tests/traptor_integration_tests.py
@@ -32,6 +32,7 @@ from time import sleep
 HOST_FOR_TESTING = os.getenv('REDIS_HOST', 'localhost')
 TRAPTOR_TYPE = os.getenv('TRAPTOR_TYPE', 'track')
 TRAPTOR_ID = int(os.getenv('TRAPTOR_ID', 0))
+RULE_ID = 12348
 
 # Create a connection to Redis
 
@@ -51,14 +52,18 @@ if redis_connection is not None:
     # Collect on tweets with the keyword `python`
     # Change the rule value if you want to collect on a different keyword or hashtag. Go nuts!
     test_track_rule = {
-      "tag": "Traptor.Test",
-      "type": "track",
-      "value": "python",
-      "description": "Test track rule for python"
+        "tag": "Traptor.Test", 
+        "value": "python", 
+        "status": "active", 
+        "description": "Test track rule for python", 
+        "appid": "test-appid", 
+        "date_added": "2017-04-02 16:58:34", 
+        "rule_type": "track", 
+        "rule_id": RULE_ID
     }
 
     try:
-        redis_key = "traptor-{}:{}:{}".format(TRAPTOR_TYPE, TRAPTOR_ID, 123)
+        redis_key = "traptor-{}:{}:{}".format(TRAPTOR_TYPE, TRAPTOR_ID, RULE_ID)
         redis_connection.hmset(redis_key, test_track_rule)
 
         print("Rule added")


### PR DESCRIPTION
**Summary**

Updated the `test_track_rule` json object in the integration test so the integration test runs successfully.

**Testing**

To start the docker containers and run the integration test, do the following:

- Clone the repo: `git clone git@github.com:istresearch/traptor.git`
- Change into the traptor directory: `cd traptor`
- Check out the branch: `git checkout pulse-3432`
- Create a **traptor.env** file from the sample: `cp traptor.env.sample traptor.env`
- Set the log level to `DEBUG` in **traptor.env**: LOG_LEVEL=DEBUG
- Set the consumer key in **traptor.env**: CONSUMER_KEY=
- Set the consumer secret in **traptor.env**: CONSUMER_SECRET=
- Set the access token in **traptor.env**: ACCESS_TOKEN=
- Set the access token secret in **traptor.env**: ACCESS_TOKEN_SECRET=
- Login to Docker Hob: `docker login`
- Build the images and launch the containers: `docker-compose up --build -d`
- Open a second command prompt and navigate to the traptor directory
- Tail the logs:
```
$ tail -f logs/traptor.log
{"message": "Setting up birdy connection", "logger": "traptor-track-0", "timestamp": "2017-04-03T21:01:52.013492Z", "level": "DEBUG"}
{"message": "Getting rules from Redis.", "logger": "traptor-track-0", "timestamp": "2017-04-03T21:01:54.574042Z", "level": "DEBUG"}
{"message": "Getting rules from Redis.", "logger": "traptor-track-0", "timestamp": "2017-04-03T21:02:54.639278Z", "level": "DEBUG"}
{"message": "Starting Traptor", "logger": "traptor-track-0", "timestamp": "2017-04-03T21:23:22.769877Z", "level": "INFO"}
{"message": "Skipping kafka connection setup", "logger": "traptor-track-0", "timestamp": "2017-04-03T21:23:22.882401Z", "level": "DEBUG"}
{"message": "Setting up birdy connection", "logger": "traptor-track-0", "timestamp": "2017-04-03T21:23:22.883287Z", "level": "DEBUG"}
{"message": "Subscribing to the Traptor notification PubSub.", "logger": "traptor-track-0", "timestamp": "2017-04-03T21:23:22.940748Z", "level": "DEBUG"}
{"message": "Getting rules from Redis.", "logger": "traptor-track-0", "timestamp": "2017-04-03T21:23:22.946647Z", "level": "DEBUG"}
{"message": "Starting the heartbeat.", "logger": "traptor-track-0", "timestamp": "2017-04-03T21:23:22.947001Z", "level": "DEBUG"}
{"message": "Waiting for rules.", "logger": "traptor-track-0", "timestamp": "2017-04-03T21:23:23.078529Z", "level": "DEBUG"}
```
- Open a bash shell in the traptor container: `docker exec -it traptor_traptor_1 bash`
- Run the integration tests: 
```
$ python tests/traptor_integration_tests.py
Giving you 15 seconds so you can start tailing the logs
Rule added
Redis Key: traptor-track:0:12348
Rule: {'status': 'active', 'rule_type': 'track', 'tag': 'Traptor.Test', 'description': 'Test track rule for python', 'appid': 'test-appid', 'date_added': '2017-04-02 16:58:34', 'rule_id': 12348, 'value': 'python'}
```
- Observe the traptor logs in the second command prompt:
`{"message": "Rule matched for tweet id: 849013963727798273", "logger": "traptor-track-0", "timestamp": "2017-04-03T21:41:19.432597Z", "level": "DEBUG"}`

You will likely see a number of tweets start flowing through the log also. You have now confirmed traptor and redis are integrated correctly.