### PR TITLE
Pulse 3756L Delete rule counters when processing starts

### DIFF
--- a/tests/test_traptor_offline.py
+++ b/tests/test_traptor_offline.py
@@ -378,6 +378,38 @@ class TestTraptor(object):
         if traptor.traptor_type == 'locations':
             assert len(traptor.rule_counters) == 0
 
+    def test_ensure_internal_rule_counters_are_properly_deleted(self, redis_rules, traptor):
+        """Ensure _delete_rule_counters are properly deleted."""
+        traptor._setup()
+        traptor.redis_conn = redis_rules
+
+        traptor.logger.info = MagicMock()
+        traptor.logger.error = MagicMock()
+
+        traptor.redis_rules = [rule for rule in traptor._get_redis_rules()]
+        traptor.twitter_rules = traptor._make_twitter_rules(traptor.redis_rules)
+
+        if traptor.traptor_type != 'locations':
+            traptor._make_rule_counters()
+            assert len(traptor.rule_counters) == 1
+
+        if traptor.traptor_type == 'track':
+            assert traptor.rule_counters['12347'] is not None
+
+            traptor._delete_rule_counters()
+            assert traptor.logger.error.call_count == 0
+            assert traptor.logger.info.call_count == 3
+
+        if traptor.traptor_type == 'follow':
+            assert traptor.rule_counters['12345'] is not None
+
+            traptor._delete_rule_counters()
+            assert traptor.logger.error.call_count == 0
+            assert traptor.logger.info.call_count == 3
+
+        if traptor.traptor_type == 'locations':
+            assert len(traptor.rule_counters) == 0
+
     def test_ensure_limit_message_counter_is_correctly_created(self, redis_rules, traptor):
         """Ensure _make_limit_message_counter makes the limit counter"""
         traptor._setup()

--- a/traptor/traptor.py
+++ b/traptor/traptor.py
@@ -377,6 +377,21 @@ class Traptor(object):
             dd_monitoring.increment('redis_error',
                                     tags=['error_type:connection_error'])
 
+    def _delete_rule_counters(self):
+        """
+        Delete the existing rule counters.
+        """
+        if len(self.rule_counters) > 0:
+            for counter in self.rule_counters:
+                try:
+                    self.rule_counters[counter].delete_key()
+                except:
+                    self.logger.error("Caught exception while deleting a rule counter", extra={
+                        'error_type': 'RedisConnectionError',
+                        'ex': traceback.format_exc()
+                    })
+            self.logger.info("Rule counters deleted successfully.")
+
     def _make_limit_message_counter(self):
         """
         Make a limit message counter to track the values of incoming limit messages.
@@ -1032,6 +1047,7 @@ class Traptor(object):
 
         # Do all the things
         while True:
+            self._delete_rule_counters()
             self._wait_for_rules()
 
             # Concatenate all of the rule['value'] fields


### PR DESCRIPTION
In order to ensure that Traptor is logging the most recent stats, delete the rule counters before stream processing begins. This has been added in such a way that each time Traptor restarts its internal rule processing the rule counters will match with the current set of rules.

**Testing**

Get the code

- `git clone git@github.com:istresearch/traptor.git`
- `git checkout pulse-3756-remove-stats-keys-on-start`

Set up your environment

- Create and activate a virtual environment (venv or Anaconda)
- Rename traptor.env.sample to traptor.env and fill in all the fields. Some defaults are provided.
- Install the requirements: `pip install -r requirements.txt`

Run the tests

In the root directory: python -m pytest -vv --cache-clear --cov=traptor --cov-report html

All tests should pass.