### PR TITLE
add deactivate call to reduce time spent shutting down stats collectors

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ redis==2.10.5
 kafka-python==1.3.1
 python-dateutil==2.5.3
 click==6.6
-scutils==1.1.0
+scutils==1.3.0dev2
 nose==1.3.7
 pymysql==0.7.2
 pytest==2.9.1

--- a/traptor/traptor.py
+++ b/traptor/traptor.py
@@ -376,6 +376,16 @@ class Traptor(object):
         if len(self.rule_counters) > 0:
             for counter in self.rule_counters:
                 try:
+                    self.rule_counters[counter].deactivate()
+                except:
+                    self.logger.error("Caught exception while deactivating a rule counter", extra={
+                        'error_type': 'ConnectionError',
+                        'ex': traceback.format_exc()
+                    })
+                    dd_monitoring.increment('redis_error',
+                                            tags=['error_type:connection_error'])
+            for counter in self.rule_counters:
+                try:
                     self.rule_counters[counter].stop()
                     self.rule_counters[counter].delete_key()
                 except:

--- a/traptor/version.py
+++ b/traptor/version.py
@@ -1,4 +1,4 @@
-__version__ = '1.4.11'
+__version__ = '1.4.11.1'
 
 if __name__ == '__main__':
     print(__version__)


### PR DESCRIPTION
This PR adds a call to `deactivate()` on stats collectors during shutdown to collapse time spent waiting for threads to exit.

**Testing**

Get the code

- `git clone git@github.com:istresearch/traptor.git`
- `git checkout hotfix-rule_counters-shutdown`

Set up your environment

- Create and activate a virtual environment (venv or Anaconda)
- Install the requirements: `pip install -r requirements.txt`

Run the tests

- In the root directory: `python -m pytest -vv --cache-clear --cov=traptor --cov-report html`

All tests should pass.