### PR TITLE
Updated Traptor with try catch for ChunkedEncodingError

### DIFF
--- a/traptor/traptor.py
+++ b/traptor/traptor.py
@@ -19,6 +19,8 @@ import threading
 from tenacity import retry, wait_exponential, stop_after_attempt, retry_if_exception_type, wait_chain, wait_fixed
 
 from dog_whistle import dw_config, dw_callback
+from requests.exceptions import ChunkedEncodingError
+
 from scutils.log_factory import LogFactory
 from scutils.stats_collector import StatsCollector
 from traptor_limit_counter import TraptorLimitCounter
@@ -1101,8 +1103,17 @@ class Traptor(object):
 
             self.restart_flag = False
 
-            # Start collecting data
-            self._main_loop()
+            try:
+                # Start collecting data
+                self._main_loop()
+            except ChunkedEncodingError as e:
+                self.logger.error("Ran into a ChunkedEncodingError while processing "
+                                  "tweets. Restarting Traptor from top of main process "
+                                  "loop", {
+                    'ex' : traceback.format_exc()
+                })
+
+
 
 
 def main():

--- a/traptor/traptor.py
+++ b/traptor/traptor.py
@@ -1204,7 +1204,7 @@ def main():
 
         dd_monitoring.increment('traptor_error_occurred',
                                 tags=['error_type:traptor_start'])
-
+        raise e
 
 if __name__ == '__main__':
     from raven import Client


### PR DESCRIPTION
# What's new

- Added a try catch block in order to catch an annoying `ChunkedEncodingError` in the requests library.

# Testing
1. Create a virtual env `virtualenv virtual-env`
2. Activate it `source ./virtual-env/bin/activate`
3. Install the reqs `pip install -r ./requirements.txt`
4. Run the tests `python -m pytest ./tests/test_traptor_offline.py`
5. Deactivate the virutal env `deactivate`
