### PR TITLE
Traptor now exits with failure if execution passes main() block

### DIFF
--- a/traptor/traptor.py
+++ b/traptor/traptor.py
@@ -1208,5 +1208,7 @@ def main():
 
 if __name__ == '__main__':
     from raven import Client
+    main()
 
-    sys.exit(main())
+    # We should never leave main()
+    sys.exit(1)


### PR DESCRIPTION
This PR makes Traptor exit with a status code of `1` if the `main()` block ever completes (which implies failure.)