### PR TITLE
adding uwsgi to requirements and a wsgi script for manager

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -18,3 +18,4 @@ datadog==0.14.0
 mockredispy==2.9.3
 tenacity==4.0.1
 urllib3==1.21.1
+uwsgi==2.0.15

--- a/traptor/manager/wsgi.py
+++ b/traptor/manager/wsgi.py
@@ -1,0 +1,8 @@
+import connexion
+from traptor import settings
+
+app = connexion.App(__name__, specification_dir=settings.API_DIR)
+
+app.add_api(settings.API_SPEC, strict_validation=True, swagger_json=True)
+
+application = app.app


### PR DESCRIPTION
This PR adds a WSGI script that allows the traptor manager to be deployed using `uwsgi`