### PR TITLE
Manager backend timeout

### DIFF
--- a/traptor/manager/backends/piscina.py
+++ b/traptor/manager/backends/piscina.py
@@ -7,14 +7,14 @@ SEARCH_TWEETS_STR = settings.TWITTER_API_URL + '/search/tweets.json?q={}&result_
 
 def get_userid_for_username(username):
     http = ProxyManager(settings.PROXY_URL, proxy_headers=make_headers(proxy_basic_auth='{}:{}'.format(settings.PROXY_USER, settings.PROXY_PASSWORD)))
-    resp = http.request('GET', USERS_LOOKUP_STR.format(username))
+    resp = http.request('GET', USERS_LOOKUP_STR.format(username), timeout=settings.PROXY_TIMEOUT)
     assert resp.status == 200, 'Twitter API error ({}): {}'.format(resp.status, resp.data)
     data = json.loads(resp.data)
     return data[0]['id_str']
 
 def get_recent_tweets_by_keyword(keyword):
     http = ProxyManager(settings.PROXY_URL, proxy_headers=make_headers(proxy_basic_auth='{}:{}'.format(settings.PROXY_USER, settings.PROXY_PASSWORD)))
-    resp = http.request('GET', SEARCH_TWEETS_STR.format(keyword))
+    resp = http.request('GET', SEARCH_TWEETS_STR.format(keyword), timeout=settings.PROXY_TIMEOUT)
     assert resp.status == 200, 'Twitter API error ({}): {}'.format(resp.status, resp.data)
     data = json.loads(resp.data)
     return data

--- a/traptor/settings.py
+++ b/traptor/settings.py
@@ -55,7 +55,7 @@ API_BACKEND = os.getenv('API_BACKEND', 'local')
 PROXY_URL = os.getenv('PROXY_URL', 'http://localhost:8080')
 PROXY_USER = os.getenv('PROXY_USER', 'test')
 PROXY_PASSWORD = os.getenv('PROXY_PASSWORD', 'test')
-PROXY_TIMEOUT = int(os.getenv('PROXY_TIMEOUT', 10))
+PROXY_TIMEOUT = int(os.getenv('PROXY_TIMEOUT', 4))
 TWITTER_API_URL = 'https://api.twitter.com/1.1'
 
 # Dog Whistle

--- a/traptor/settings.py
+++ b/traptor/settings.py
@@ -55,6 +55,7 @@ API_BACKEND = os.getenv('API_BACKEND', 'local')
 PROXY_URL = os.getenv('PROXY_URL', 'http://localhost:8080')
 PROXY_USER = os.getenv('PROXY_USER', 'test')
 PROXY_PASSWORD = os.getenv('PROXY_PASSWORD', 'test')
+PROXY_TIMEOUT = int(os.getenv('PROXY_TIMEOUT', 10))
 TWITTER_API_URL = 'https://api.twitter.com/1.1'
 
 # Dog Whistle


### PR DESCRIPTION
Twitter rule validation performs much better with a low timeout set on connections through a piscina proxy; updating settings and piscina backend. 