### PR TITLE
adding Dockerfile for twitterapi image

### DIFF
--- a/Dockerfile.twitterapi
+++ b/Dockerfile.twitterapi
@@ -14,10 +14,11 @@ ENV TWITTER_API_WORKERS $TWITTER_API_WORKERS
 COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 RUN rm requirements.txt
-RUN mkdir -p /usr/src/app
 
 # Copy over code
 COPY . /usr/src/app
+WORKDIR /usr/src/app
+RUN pip install .
 
 # Start Traptor Manager API
 WORKDIR /usr/src/app/traptor/manager

--- a/Dockerfile.twitterapi
+++ b/Dockerfile.twitterapi
@@ -1,0 +1,24 @@
+FROM python:2
+MAINTAINER Marti Martinez <marti.martinez@istresearch.com>
+
+ARG BUILD_NUMBER=0
+ENV BUILD_NUMBER $BUILD_NUMBER
+
+ARG TWITTER_API_PORT=5000
+ENV TWITTER_API_PORT $TWITTER_API_PORT
+
+ARG TWITTER_API_WORKERS=8
+ENV TWITTER_API_WORKERS $TWITTER_API_WORKERS
+
+# Install Python requirements
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+RUN rm requirements.txt
+RUN mkdir -p /usr/src/app
+
+# Copy over code
+COPY . /usr/src/app
+
+# Start Traptor Manager API
+WORKDIR /usr/src/app/traptor/manager
+CMD uwsgi --http :${TWITTER_API_PORT} -p ${TWITTER_API_WORKERS} -w wsgi


### PR DESCRIPTION
This PR adds a separate dockerfile for the `twitterapi` image, implementing the traptor manager API. This image provides a `uwsgi` server with multiple worker processes. The following environment variables specific to this image can be provided to alter the configuration of a container:
- `TWITTER_API_PORT` - sets the bind port for the `uwsgi` server (default: `5000`)
- `TWITTER_API_WORKERS` - sets the number of `uwsgi` worker processes (default: `8`)