### PR TITLE
Pulse 4077: Add a DD gauge and some counters

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -17,6 +17,6 @@ redis==2.10.5
 requests==2.9.1
 requests-oauthlib==0.6.1
 scutils==1.3.0dev2
-tenacity==4.0.1
+tenacity>=4.0.1,<=4.3
 urllib3==1.21.1
 uwsgi==2.0.15

--- a/traptor/dd_monitoring.py
+++ b/traptor/dd_monitoring.py
@@ -3,11 +3,12 @@
 # See https://github.com/DataDog/datadogpy#quick-start-guide
 ###############################################################################
 import os
-from datadog import initialize
+from datadog import statsd, initialize
 
 traptor_type = os.getenv('TRAPTOR_TYPE', 'track')
 traptor_id = os.getenv('TRAPTOR_ID', '0')
 
+# pseudo-CONST default tag values, if change, do so before threading starts.
 DEFAULT_TAGS = [
     'traptor_type:{}'.format(traptor_type),
     'traptor_id:{}'.format(traptor_id),
@@ -18,10 +19,9 @@ options = {
 }
 initialize(**options)
 
-
-from datadog import statsd
+# CONST metric names and their actual dd value.
 DATADOG_METRICS = {
-    'heartbeat_message_sent_success' :'traptor.src.heartbeat.success.count',
+    'heartbeat_message_sent_success': 'traptor.src.heartbeat.success.count',
     'heartbeat_message_sent_failure': 'traptor.src.heartbeat.failure.count',
     'restart_message_received': 'traptor.src.restart_message.success.count',
     'kafka_error': 'traptor.src.kafka.error',

--- a/traptor/settings.py
+++ b/traptor/settings.py
@@ -59,6 +59,8 @@ PROXY_TIMEOUT = int(os.getenv('PROXY_TIMEOUT', 4))
 TWITTER_API_URL = 'https://api.twitter.com/1.1'
 
 # Dog Whistle
+DWC_SEND_TO_KAFKA_ENRICHED = 'tweet_to_kafka_enriched'
+DWC_ERROR_SEND_TO_KAFKA = 'Caught exception adding Twitter message to Kafka'
 DWC_RETRY_TWITTER = 'traptor_retry_twitter_api'
 DWC_RETRY_REDIS = 'traptor_retry_redis_api'
 DWC_RETRY_KAFKA = 'traptor_retry_kakfa_api'

--- a/traptor/settings.py
+++ b/traptor/settings.py
@@ -64,6 +64,7 @@ DWC_RETRY_REDIS = 'traptor_retry_redis_api'
 DWC_RETRY_KAFKA = 'traptor_retry_kakfa_api'
 DWG_RULE_COUNT = {'name': 'Traptor Rule Count',
                    'key': 'traptor_rule_count', 'value': 'rule_count'}
+# Match Count gauge not in use, yet, was determined to complex to put in now.
 DWG_MATCH_COUNT = {'name': 'Traptor Num Matches For ID',
                    'key': 'traptor_num_matches_for_id', 'value': 'match_count'}
 DW_ENABLED = bool(os.getenv('DW_ENABLED', 'False') == 'True')

--- a/traptor/settings.py
+++ b/traptor/settings.py
@@ -59,6 +59,10 @@ PROXY_TIMEOUT = int(os.getenv('PROXY_TIMEOUT', 4))
 TWITTER_API_URL = 'https://api.twitter.com/1.1'
 
 # Dog Whistle
+DWG_RULE_COUNT = {'name': 'Traptor Rule Count',
+                   'key': 'traptor_rule_count', 'value': 'rule_count'}
+DWG_MATCH_COUNT = {'name': 'Traptor Num Matches For ID',
+                   'key': 'traptor_num_matches_for_id', 'value': 'match_count'}
 DW_ENABLED = bool(os.getenv('DW_ENABLED', 'False') == 'True')
 DW_CONFIG = {
     'name': os.getenv('DW_NAME', 'traptor'),
@@ -68,6 +72,10 @@ DW_CONFIG = {
         'local': bool(os.getenv('DW_LOCAL', 'True') == 'True')
     },
     'metrics': {
+        'gauges': [
+            (DWG_RULE_COUNT['name'], DWG_RULE_COUNT['key'], DWG_RULE_COUNT['value']),
+            (DWG_MATCH_COUNT['name'], DWG_MATCH_COUNT['key'], DWG_MATCH_COUNT['value']),
+        ]
     }
 }
 

--- a/traptor/settings.py
+++ b/traptor/settings.py
@@ -59,6 +59,9 @@ PROXY_TIMEOUT = int(os.getenv('PROXY_TIMEOUT', 4))
 TWITTER_API_URL = 'https://api.twitter.com/1.1'
 
 # Dog Whistle
+DWC_RETRY_TWITTER = 'traptor_retry_twitter_api'
+DWC_RETRY_REDIS = 'traptor_retry_redis_api'
+DWC_RETRY_KAFKA = 'traptor_retry_kakfa_api'
 DWG_RULE_COUNT = {'name': 'Traptor Rule Count',
                    'key': 'traptor_rule_count', 'value': 'rule_count'}
 DWG_MATCH_COUNT = {'name': 'Traptor Num Matches For ID',

--- a/traptor/traptor.py
+++ b/traptor/traptor.py
@@ -1163,7 +1163,6 @@ class Traptor(object):
         while True:
             try:
                 self._add_heartbeat_message_to_redis(hb_interval)
-                self.rule_counters
             except Exception as e:
                 theLogMsg = "Caught exception while adding the heartbeat message to Redis"
                 self.logger.error(theLogMsg, extra=logExtra(e))

--- a/traptor/traptor.py
+++ b/traptor/traptor.py
@@ -248,19 +248,13 @@ class Traptor(object):
 
     def __repr__(self):
         return 'Traptor(' \
-               + 'redis='+repr(self.redis_conn) \
-               + ', redis_pubsub='+repr(self.pubsub_conn) \
-               + ', redis_heartbeat='+repr(self.heartbeat_conn) \
+               + 'type='+repr(self.traptor_type) \
+               + ', id='+repr(self.traptor_id) \
                + ', notify_channel='+repr(self.traptor_notify_channel) \
                + ', check_interval='+repr(self.rule_check_interval) \
-               + ', type='+repr(self.traptor_type) \
-               + ', id='+repr(self.traptor_id) \
-               + ', apikeys='+repr(self.apikeys) \
                + ', kafka_on='+repr(self.kafka_enabled) \
-               + ', khosts='+repr(self.kafka_hosts) \
                + ', ktopic='+repr(self.kafka_topic) \
                + ', sentry_on='+repr(self.use_sentry) \
-               + ', sentry_url='+repr(self.sentry_url) \
                + ', test_on='+repr(self.test) \
                + ', stats_on='+repr(self.enable_stats_collection) \
                + ')'
@@ -1216,19 +1210,14 @@ class Traptor(object):
                                             tags=['error_type:json_loads_error'])
                 else:
                     enriched_data = self._enrich_tweet(tweet)
-                    # #4204 - since 1.4.14
-                    self.logger.info('tweet_to_kafka_enriched', extra=logExtra())
+                    # #4204 - since 1.4.13
+                    theLogMsg = settings.DWC_SEND_TO_KAFKA_ENRICHED
+                    self.logger.info(theLogMsg, extra=logExtra())
                     if self.kafka_enabled:
                         try:
                             self._send_enriched_data_to_kafka(tweet, enriched_data)
-                            theTagPrefix = self.name+':'
-                            theTags = [
-                                    theTagPrefix+self.traptor_type,
-                                    theTagPrefix+hashlib.md5(self.kafka_hosts)
-                            ]
-                            dd_monitoring.increment('tweet_to_kafka_enriched', tags=theTags)
                         except Exception as e:
-                            theLogMsg = "Caught exception adding Twitter message to Kafka"
+                            theLogMsg = settings.DWC_ERROR_SEND_TO_KAFKA
                             self.logger.error(theLogMsg, extra=logExtra(e))
                             dd_monitoring.increment('tweet_to_kafka_failure',
                                                     tags=['error_type:kafka'])


### PR DESCRIPTION
Four new metrics sent to DataDog:

A gauge for the number of rules assigned to the traptor whenever rules get assigned.
```
DWG_RULE_COUNT = {'name': 'Traptor Rule Count',
                   'key': 'traptor_rule_count', 'value': 'rule_count'}
```

An increment metric for each @retry
```
DWC_RETRY_TWITTER = 'traptor_retry_twitter_api'
DWC_RETRY_REDIS = 'traptor_retry_redis_api'
DWC_RETRY_KAFKA = 'traptor_retry_kakfa_api'
```