### PR TITLE
Pulse 4225 log limit messages

### DIFF
--- a/traptor/traptor.py
+++ b/traptor/traptor.py
@@ -997,8 +997,8 @@ class Traptor(object):
         enriched_data = dict()
 
         if self._message_is_limit_message(tweet):
-            # Increment counter
-            dd_monitoring.increment('limit_message_received')
+            # Log limit message
+            self.logger.warn('limit message received', extra={'limit_count':'limit_count', 'traptor_type': self.traptor_type, 'traptor_id': self.traptor_id})
             # Send DD the limit message value
             limit_count = tweet.get('limit').get(self.traptor_type, None)
             dd_monitoring.gauge('limit_message_count', limit_count, [])

--- a/traptor/traptor.py
+++ b/traptor/traptor.py
@@ -998,7 +998,7 @@ class Traptor(object):
 
         if self._message_is_limit_message(tweet):
             # Log limit message
-            self.logger.warn('limit message received', extra={'limit_count':'limit_count', 'traptor_type': self.traptor_type, 'traptor_id': self.traptor_id})
+            self.logger.warn('limit message received', extra={'limit_count': limit_count, 'traptor_type': self.traptor_type, 'traptor_id': self.traptor_id})
             # Send DD the limit message value
             limit_count = tweet.get('limit').get(self.traptor_type, None)
             dd_monitoring.gauge('limit_message_count', limit_count, [])

--- a/traptor/traptor.py
+++ b/traptor/traptor.py
@@ -997,13 +997,13 @@ class Traptor(object):
         enriched_data = dict()
 
         if self._message_is_limit_message(tweet):
-            # Log limit message
-            self.logger.warn('limit message received', extra={'limit_count': limit_count, 'traptor_type': self.traptor_type, 'traptor_id': self.traptor_id})
             # Send DD the limit message value
             limit_count = tweet.get('limit').get(self.traptor_type, None)
             dd_monitoring.gauge('limit_message_count', limit_count, [])
             # Store the limit count in Redis
             self._increment_limit_message_counter(limit_count=limit_count)
+            # Log limit message
+            self.logger.warn('limit message received', extra={'limit_count': limit_count, 'traptor_type': self.traptor_type, 'traptor_id': self.traptor_id})
         elif self._message_is_tweet(tweet):
             try:
                 # Add the initial traptor fields


### PR DESCRIPTION
This PR adds a log message each time a limit tweet is processed, replacing an explicit DataDog counter with implicit DogWhistle counter and providing data that will flow into Elasticsearch for visualization. 

## Testing

```
git clone git@github.com:istresearch/traptor.git
cd traptor
git checkout pulse-4225-log-limit-messages
virtualenv ~/env
. ~/env/bin/activate
pip install -r requirements.txt
python -m pytest tests/test_traptor_offline.py
```