### PR TITLE
Pulse 4718 - HOTFIX for dogwhistle

### DIFF
--- a/traptor/settings.py
+++ b/traptor/settings.py
@@ -72,27 +72,28 @@ DWG_MATCH_COUNT = {'name': 'Traptor Num Matches For ID',
 DW_ENABLED = bool(os.getenv('DW_ENABLED', 'False') == 'True')
 DW_CONFIG = {
     'name': os.getenv('DW_NAME', 'traptor'),
+    'allow_extra_tags': True,
     'options': {
         'statsd_host': os.getenv('DW_STATSD_HOST', 'statsd'),
         'statsd_port': os.getenv('DW_STATSD_PORT', 8125),
         'local': bool(os.getenv('DW_LOCAL', 'True') == 'True')
     },
-    'counters': [
-        ('heartbeat_message_sent_success', 'traptor.src.heartbeat.success.count'),
-        ('heartbeat_message_sent_failure', 'traptor.src.heartbeat.failure.count'),
-        ('restart_message_received', 'traptor.src.restart_message.success.count'),
-        ('kafka_error', 'traptor.src.kafka.error'),
-        ('redis_error', 'traptor.src.redis.error'),
-        ('traptor_error_occurred', 'traptor.src.error.count'),
-        ('twitter_error_occurred', 'traptor.src.twitter.error.count'),
-        ('tweet_process_success', 'traptor.src.tweet_process.success'),
-        ('tweet_process_failure', 'traptor.src.tweet_process.failure'),
-        ('tweet_to_kafka_success', 'traptor.src.tweet_to_kafka.success'),
-        ('tweet_to_kafka_failure', 'traptor.src.tweet_to_kafka.failure'),
-        ('limit_message_received', 'traptor.src.limit.messages.count'),
-        ('limit_message_count', 'traptor.src.limit.current_limited')
-    ],
     'metrics': {
+        'counters': [
+            ('heartbeat_message_sent_success', 'src.heartbeat.success.count'),
+            ('heartbeat_message_sent_failure', 'src.heartbeat.failure.count'),
+            ('restart_message_received', 'src.restart_message.success.count'),
+            ('kafka_error', 'src.kafka.error'),
+            ('redis_error', 'src.redis.error'),
+            ('traptor_error_occurred', 'src.error.count'),
+            ('twitter_error_occurred', 'src.twitter.error.count'),
+            ('tweet_process_success', 'src.tweet_process.success'),
+            ('tweet_process_failure', 'src.tweet_process.failure'),
+            ('tweet_to_kafka_success', 'src.tweet_to_kafka.success'),
+            ('tweet_to_kafka_failure', 'src.tweet_to_kafka.failure'),
+            ('limit_message_received', 'src.limit.messages.count'),
+            ('limit_message_count', 'src.limit.current_limited')
+        ],
         'gauges': [
             (DWG_RULE_COUNT['name'], DWG_RULE_COUNT['key'], DWG_RULE_COUNT['value']),
             (DWG_MATCH_COUNT['name'], DWG_MATCH_COUNT['key'], DWG_MATCH_COUNT['value']),

--- a/traptor/settings.py
+++ b/traptor/settings.py
@@ -77,6 +77,21 @@ DW_CONFIG = {
         'statsd_port': os.getenv('DW_STATSD_PORT', 8125),
         'local': bool(os.getenv('DW_LOCAL', 'True') == 'True')
     },
+    'counters': [
+        ('heartbeat_message_sent_success', 'traptor.src.heartbeat.success.count'),
+        ('heartbeat_message_sent_failure', 'traptor.src.heartbeat.failure.count'),
+        ('restart_message_received', 'traptor.src.restart_message.success.count'),
+        ('kafka_error', 'traptor.src.kafka.error'),
+        ('redis_error', 'traptor.src.redis.error'),
+        ('traptor_error_occurred', 'traptor.src.error.count'),
+        ('twitter_error_occurred', 'traptor.src.twitter.error.count'),
+        ('tweet_process_success', 'traptor.src.tweet_process.success'),
+        ('tweet_process_failure', 'traptor.src.tweet_process.failure'),
+        ('tweet_to_kafka_success', 'traptor.src.tweet_to_kafka.success'),
+        ('tweet_to_kafka_failure', 'traptor.src.tweet_to_kafka.failure'),
+        ('limit_message_received', 'traptor.src.limit.messages.count'),
+        ('limit_message_count', 'traptor.src.limit.current_limited')
+    ],
     'metrics': {
         'gauges': [
             (DWG_RULE_COUNT['name'], DWG_RULE_COUNT['key'], DWG_RULE_COUNT['value']),

--- a/traptor/traptor.py
+++ b/traptor/traptor.py
@@ -1389,7 +1389,7 @@ def createArgumentParser():
     parser.add_argument(
             '--delay',
             action='store_true',  # which defaults to False.
-            help='Skips the artificial delay to wait 30 seconds.'
+            help='Inserts an artificial delay to wait 30 seconds before startup.'
     )
     parser.add_argument(
             '--test',

--- a/traptor/traptor.py
+++ b/traptor/traptor.py
@@ -96,9 +96,9 @@ def logExtra(*info_args):
     """
     result = {
             'component': my_component,
-            my_component+'-type': my_traptor_type,
-            my_component+'-id': my_traptor_id,
-            my_component+'-version': version.__version__,
+            my_component+'_version': version.__version__,
+            'tags': ["traptor_type:{}".format(my_traptor_type),
+                     "traptor_id:{}".format(my_traptor_id)]
     }
     for info in info_args:
         if isinstance(info, types.StringType):

--- a/traptor/traptor.py
+++ b/traptor/traptor.py
@@ -31,15 +31,10 @@ from scutils.log_factory import LogFactory
 from scutils.stats_collector import StatsCollector
 from traptor_limit_counter import TraptorLimitCounter
 
-import logging
 import settings
-import hashlib
 import argparse
 import version
 import types
-
-FORMAT = '%(asctime)-15s %(message)s'
-logging.basicConfig(level='INFO', format=FORMAT)
 
 # Vars initialized once, then threadsafe to use
 my_component = 'traptor'

--- a/traptor/traptor.py
+++ b/traptor/traptor.py
@@ -1387,8 +1387,8 @@ def createArgumentParser():
     """
     parser = argparse.ArgumentParser()
     parser.add_argument(
-            '--skipdelay',
-            action='store_false',  # which defaults to True.
+            '--delay',
+            action='store_true',  # which defaults to False.
             help='Skips the artificial delay to wait 30 seconds.'
     )
     parser.add_argument(
@@ -1543,7 +1543,7 @@ def main():
         my_logger.register_callback('>=INFO', dw_callback)
 
     # Wait until all the other containers are up and going...
-    if not args.skipdelay:
+    if args.delay:
         print('waiting 30 sec for other containers to get up and going...')
         time.sleep(30)
     else:

--- a/traptor/traptor.py
+++ b/traptor/traptor.py
@@ -1388,7 +1388,7 @@ def createArgumentParser():
     parser = argparse.ArgumentParser()
     parser.add_argument(
             '--skipdelay',
-            action='store_true',  # which defaults to False.
+            action='store_false',  # which defaults to True.
             help='Skips the artificial delay to wait 30 seconds.'
     )
     parser.add_argument(

--- a/traptor/version.py
+++ b/traptor/version.py
@@ -1,4 +1,4 @@
-__version__ = '1.4.14.0'
+__version__ = '1.4.14.1'
 
 if __name__ == '__main__':
     print(__version__)


### PR DESCRIPTION
This adds the missing counter metrics for dogwhistle.

It also removes an extraneous stdout logger and toggles the 30 second sleep out of the default startup.

## Testing
Add a `traptor.env` file (copy traptor.env.sample) during testing, defining values for:
```
CONSUMER_KEY=
CONSUMER_SECRET=
ACCESS_TOKEN=
ACCESS_TOKEN_SECRET=
```
Then execute:
```
git clone git@github.com:istresearch/traptor.git
cd traptor
git checkout PULSE-4718
virtualenv ~/env
. ~/env/bin/activate
pip install -r requirements.txt
docker-compose up -d --build
```
Once running, go to Graphite at http://localhost:8002 and ensure `stats.traptor.src.heartbeat.success.count` is being recorded.
