### PR TITLE
Pulse 4718 - Correcting [more] DataDog metrics that were lost

### DIFF
--- a/traptor/settings.py
+++ b/traptor/settings.py
@@ -81,14 +81,13 @@ DW_CONFIG = {
     'metrics': {
         'counters': [
             ('heartbeat_message_sent_success', 'src.heartbeat.success.count'),
-            ('heartbeat_message_sent_failure', 'src.heartbeat.failure.count'),
+            ('Caught exception while adding the heartbeat message to Redis', 'src.heartbeat.failure.count'),
             ('restart_message_received', 'src.restart_message.success.count'),
             ('kafka_error', 'src.kafka.error'),
             ('redis_error', 'src.redis.error'),
             ('traptor_error_occurred', 'src.error.count'),
             ('twitter_error_occurred', 'src.twitter.error.count'),
             ('tweet_process_success', 'src.tweet_process.success'),
-            ('tweet_process_failure', 'src.tweet_process.failure'),
             ('tweet_to_kafka_success', 'src.tweet_to_kafka.success'),
             ('tweet_to_kafka_failure', 'src.tweet_to_kafka.failure'),
             ('limit_message_received', 'src.limit.messages.count'),

--- a/traptor/traptor.py
+++ b/traptor/traptor.py
@@ -1097,7 +1097,7 @@ class Traptor(object):
             # Store the limit count in Redis
             self._increment_limit_message_counter(limit_count=limit_count)
             # Log limit message
-            self.logger.warn('limit message received', extra={'limit_count': limit_count, 'traptor_type': self.traptor_type, 'traptor_id': self.traptor_id})
+            self.logger.info('limit_message_received', extra=logExtra({'limit_count': limit_count}))
         elif self._message_is_tweet(tweet):
             try:
                 # Add the initial traptor fields
@@ -1158,6 +1158,7 @@ class Traptor(object):
                 if t[0] == self.traptor_type and t[1] == str(self.traptor_id):
                     # Restart flag found for our specific instance
                     self._setRestartSearchFlag(True)
+                    self.logger.info('restart_message_received', extra=logExtra())
 
     @retry(
         wait=wait_exponential(multiplier=1, max=10),

--- a/traptor/version.py
+++ b/traptor/version.py
@@ -1,4 +1,4 @@
-__version__ = '1.4.15.0'
+__version__ = '1.4.14.2'
 
 if __name__ == '__main__':
     print(__version__)

--- a/traptor/version.py
+++ b/traptor/version.py
@@ -1,4 +1,4 @@
-__version__ = '1.4.14.1'
+__version__ = '1.4.15.0'
 
 if __name__ == '__main__':
     print(__version__)


### PR DESCRIPTION
This adds more missing counter metrics for dogwhistle.

## Testing
Add a `traptor.env` file (copy traptor.env.sample) during testing, defining values for:
```
CONSUMER_KEY=
CONSUMER_SECRET=
ACCESS_TOKEN=
ACCESS_TOKEN_SECRET=
```
Then execute:
```
git clone git@github.com:istresearch/traptor.git
cd traptor
git checkout PULSE-4718
virtualenv ~/env
. ~/env/bin/activate
pip install -r requirements.txt
docker-compose up -d --build
```
Once running, go to Graphite at http://localhost:8002 and ensure `stats.traptor.src.heartbeat.success.count` is being recorded.

After the traptor is confirmed up and stable, we're going to issue a command to restart.
```
docker-compose exec redis redis-cli
> select 2
OK
> PUBLISH traptor-notify track:0
(integer) 1
```
Now go back to Graphite, and refresh the page. Now look for `stats.traptor.src.restart_message.count`.

You should get an event every time you issue the restart command.