### PR TITLE
Pulse 4733 - Traptor DogWhistle tags not showing

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,9 +21,9 @@ services:
       - REDIS_PORT=6379
       - REDIS_DB=2
       - DW_ENABLED=True
-      - DATADOG_LOCAL=True # True for local dev
-      - DATADOG_STATSD_HOST= # on a linux host set to 172.17.0.1 and on mac os host set to docker.for.mac.localhost
-      - DATADOG_STATSD_PORT=8125 # port statsd container is listening on
+      - DW_LOCAL=True # True for local dev
+      - DW_STATSD_HOST= # on a linux host set to 172.17.0.1 and on mac os host set to docker.for.mac.localhost
+      - DW_STATSD_PORT=8125 # port statsd container is listening on
     restart: always
 
   redis:

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ birdy==0.2
 click==6.6
 connexion==1.1.10
 datadog==0.14.0
-dog-whistle==0.4.0
+dog-whistle==0.5.0
 kafka-python==1.3.1
 mockredispy==2.9.3
 nose==1.3.7


### PR DESCRIPTION
For this PR I upgraded dog-whistle to 0.5.0 and adjusted the docker-compose file to list the correct DW variables. 

# Testing
- Point dog-whistle to a working dd-agent:
```
- DW_ENABLED=True
- DW_LOCAL=False
- DW_STATSD_HOST= statsd
- DW_STATSD_PORT=8125 
```
- Start traptor: `docker-compose up --build -d`
- After a few minutes check datadog. The traptor metrics should now have traptor_id and traptor_type tags.