### PR TITLE
Pulse 4909 - Piscina fails on keywords with spaces

### DIFF
--- a/traptor/manager/api.py
+++ b/traptor/manager/api.py
@@ -58,6 +58,7 @@ def _validate_follow_rule(value):
 
 def _validate_track_rule(value):
     response = {}
+    value = value.encode('utf-8')
     search_results = get_recent_tweets_by_keyword(value)
     tweet_creation_times = []
     for result in search_results['statuses']:

--- a/traptor/manager/backends/piscina.py
+++ b/traptor/manager/backends/piscina.py
@@ -2,19 +2,35 @@ import json
 from urllib3 import ProxyManager, make_headers
 from traptor import settings
 
-USERS_LOOKUP_STR = settings.TWITTER_API_URL + '/users/lookup.json?screen_name={}'
-SEARCH_TWEETS_STR = settings.TWITTER_API_URL + '/search/tweets.json?q={}&result_type=recent&count=100&include_entities=false'
+USERS_LOOKUP_STR = settings.TWITTER_API_URL + '/users/lookup.json'
+SEARCH_TWEETS_STR = settings.TWITTER_API_URL + '/search/tweets.json'
+
+def _get_proxy():
+    return ProxyManager(settings.PROXY_URL, proxy_headers=make_headers(proxy_basic_auth='{}:{}'.format(settings.PROXY_USER, settings.PROXY_PASSWORD)))
 
 def get_userid_for_username(username):
-    http = ProxyManager(settings.PROXY_URL, proxy_headers=make_headers(proxy_basic_auth='{}:{}'.format(settings.PROXY_USER, settings.PROXY_PASSWORD)))
-    resp = http.request('GET', USERS_LOOKUP_STR.format(username), timeout=settings.PROXY_TIMEOUT)
+    http = _get_proxy()
+
+    fields = {
+        'screen_name': username,
+    }
+
+    resp = http.request('GET', USERS_LOOKUP_STR, fields, timeout=settings.PROXY_TIMEOUT)
     assert resp.status == 200, 'Twitter API error ({}): {}'.format(resp.status, resp.data)
     data = json.loads(resp.data)
     return data[0]['id_str']
 
 def get_recent_tweets_by_keyword(keyword):
-    http = ProxyManager(settings.PROXY_URL, proxy_headers=make_headers(proxy_basic_auth='{}:{}'.format(settings.PROXY_USER, settings.PROXY_PASSWORD)))
-    resp = http.request('GET', SEARCH_TWEETS_STR.format(keyword), timeout=settings.PROXY_TIMEOUT)
+    http = _get_proxy()
+
+    fields = {
+        'q': keyword,
+        'result_type': 'recent',
+        'count': 100,
+        'include_entities': 'false'
+    }
+
+    resp = http.request('GET', SEARCH_TWEETS_STR, fields, timeout=settings.PROXY_TIMEOUT)
     assert resp.status == 200, 'Twitter API error ({}): {}'.format(resp.status, resp.data)
     data = json.loads(resp.data)
     return data


### PR DESCRIPTION
# What's New?

I adjusted twitterapi's piscina client to encode all GET fields. 

# Testing

Ensure piscina is configured and running. Create a `local.ini` file in the `./piscina` directory, and uncomment the ini volume in docker-compose.yml for piscina:

```
[ProxyServer]

username = test
password = test
ip = 0.0.0.0
port = 8080

[Twitter]

ConsumerKey = CONSUMER_KEY
ConsumerSecret = CONSUMER_SECRET
AppToken = APP_TOKEN
AppTokenSecret = APP_TOKEN_SECRET

[UIServer]

ip = 0.0.0.0
port = 8000
```

Goto the UI at http://localhost:8000 and configure it with your twitter account

`docker-compose up --build -d`

Send a CURL request to twitterapi:
```
curl -X POST \
  http://localhost:5000/v1.0/validate \
  -H 'content-type: application/json' \
  -d '{
	"type":"keyword",
	"value":"apple zebra"
}'
```
You should get back a valid response
```
{
    "context": {
        "type": "keyword",
        "value": "apple zebra"
    },
    "status": "ok",
    "tweets_per_second": 0.00018176069311410975
}
```
Ensure that usernames still work:
```
curl -X POST \
  http://localhost:5000/v1.0/validate \
  -H 'content-type: application/json' \
  -d '{
	"type":"username",
	"value":"apple"
}'
```
Response
```
{
    "context": {
        "type": "username",
        "value": "apple"
    },
    "status": "ok",
    "userid": "380749300"
}
```

Check special character support
```
curl -X POST \
  http://localhost:5000/v1.0/validate \
  -H 'content-type: application/json' \
  -d '{
	"type":"keyword",
	"value":"véridiques"
}'
```
Response
```
{
    "context": {
        "type": "keyword",
        "value": "véridiques"
    },
    "status": "ok",
    "tweets_per_second": 0.00018652679643957652
}
```