### PR TITLE
Pulse 4843 - Add validation to traptor to handle malformed user IDs

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,7 +22,7 @@ services:
       - REDIS_DB=2
       - DW_ENABLED=True
       - DW_LOCAL=True # True for local dev
-      - DW_STATSD_HOST= # on a linux host set to 172.17.0.1 and on mac os host set to docker.for.mac.localhost
+      - DW_STATSD_HOST=statsd # on a linux host set to 172.17.0.1 and on mac os host set to docker.for.mac.localhost
       - DW_STATSD_PORT=8125 # port statsd container is listening on
     restart: always
 

--- a/tests/test_traptor_offline.py
+++ b/tests/test_traptor_offline.py
@@ -517,3 +517,12 @@ class TestTraptor(object):
             enriched_data = traptor._enrich_tweet(tweet)
 
             assert enriched_data['traptor']['rule_value'] == 'tweet'
+
+    def test_invalid_follow_returns_blank(self, traptor):
+        traptor.logger = MagicMock()
+        traptor.logger = MagicMock()
+        traptor.logger = MagicMock()
+        traptor.traptor_type = 'follow'
+        rules_str = traptor._make_twitter_rules([{"value": "ishouldbeint"}])
+
+        assert len(rules_str) == 0

--- a/traptor/traptor.py
+++ b/traptor/traptor.py
@@ -513,7 +513,7 @@ class Traptor(object):
 
             for rule in rules:
                 try:
-                    if isinstance(rule['value'], (int, long)) or rule['value'].isdigit():
+                    if str(rule['value']).isdigit():
                         valid_rules.append(rule['value'])
                     else:
                         raise ValueError("Invalid follow rule")

--- a/traptor/traptor.py
+++ b/traptor/traptor.py
@@ -507,7 +507,23 @@ class Traptor(object):
             :returns: A ``str`` of twitter rules that can be loaded into the
                       a birdy twitter stream.
         """
-        rules_str = ','.join([rule['value'] for rule in rules])
+
+        if self.traptor_type == 'follow':
+            valid_rules = []
+
+            for rule in rules:
+                try:
+                    if isinstance(rule['value'], (int, long)) or rule['value'].isdigit():
+                        valid_rules.append(rule['value'])
+                    else:
+                        raise ValueError("Invalid follow rule")
+                except Exception as e:
+                    self.logger.error("Skipping invalid follow rule", extra=logExtra({"ex": e, "rule": rule}))
+
+            rules_str = ','.join(valid_rules)
+        else:
+            rules_str = ','.join([rule['value'] for rule in rules])
+
         self.logger.debug('Twitter rules', extra=logExtra({
                 'rules_str': rules_str.encode('utf-8')
         }))
@@ -1318,6 +1334,12 @@ class Traptor(object):
 
             # Concatenate all of the rule['value'] fields
             self.twitter_rules = self._make_twitter_rules(self.redis_rules)
+
+            if len(self.twitter_rules) == 0:
+                self.logger.info("No rules returned")
+                time.sleep(self.rule_check_interval)
+                continue
+
             self.logger.debug('Twitter rules', extra=logExtra({
                     'dbg-rules': self.twitter_rules.encode('utf-8')
             }))

--- a/traptor/traptor.py
+++ b/traptor/traptor.py
@@ -1336,7 +1336,9 @@ class Traptor(object):
             self.twitter_rules = self._make_twitter_rules(self.redis_rules)
 
             if len(self.twitter_rules) == 0:
-                self.logger.info("No rules returned")
+                self.logger.warn('No valid Redis rules assigned', extra=logExtra({
+                    'sleep_seconds': self.rule_check_interval
+                }))
                 time.sleep(self.rule_check_interval)
                 continue
 


### PR DESCRIPTION
# What's New?

Validation has been added to allow traptor to gracefully handle malformed user IDs. If it encounters one - it will simply log an error and skip it, rather than killing the entire twitter stream. 

# Unit Testing

```
git clone git@github.com:istresearch/traptor.git
cd traptor
git checkout PULSE-4843
virtualenv ~/env
. ~/env/bin/activate
pip install -r requirements.txt
python -m pytest tests/test_traptor_offline.py
```

# Integration Testing

Config traptor.env with your credentials and ensure it is setup as a `follow` traptor

`docker-compose up -d --build`

Populate the traptor redis db with a ruleset. Ensure that it contains at least one invalid follow rule (non-numeric in place of the value)

When traptor runs you should see the following log message: `Skipping invalid follow rule`

If there are no valid rules you will further see: `No rules returned` 