### PR TITLE
PULSE-5028 - Retry on connection aborted errors

### DIFF
--- a/traptor/manager/api.py
+++ b/traptor/manager/api.py
@@ -7,19 +7,18 @@ from scutils.log_factory import LogFactory
 from traptor import settings
 from __strings__ import *
 
-if settings.API_BACKEND == 'piscina':
-    from backends.piscina import get_userid_for_username, get_recent_tweets_by_keyword
-else: 
-    from backends.local import get_userid_for_username, get_recent_tweets_by_keyword
-
 # Initialize Logging
-
 logger = LogFactory.get_instance(name=os.getenv('LOG_NAME', settings.LOG_NAME),
             json=os.getenv('LOG_JSON', settings.LOG_JSON) == 'True',
             stdout=os.getenv('LOG_STDOUT', settings.LOG_STDOUT) == 'True',
             level=os.getenv('LOG_LEVEL', settings.LOG_LEVEL),
             dir=os.getenv('LOG_DIR', settings.LOG_DIR),
             file=os.getenv('LOG_FILE', settings.LOG_FILE))
+
+if settings.API_BACKEND == 'piscina':
+    from backends.piscina import get_userid_for_username, get_recent_tweets_by_keyword
+else: 
+    from backends.local import get_userid_for_username, get_recent_tweets_by_keyword
 
 if settings.DW_ENABLED:
     dw_config(settings.DW_CONFIG)

--- a/traptor/manager/backends/local.py
+++ b/traptor/manager/backends/local.py
@@ -2,6 +2,7 @@ import os
 from birdy.twitter import AppClient, TwitterClientError
 from traptor import settings
 from api import logger
+from time import sleep
 
 def retry_on_error(func):
     def func_wrapper(*args, **kwargs):
@@ -16,6 +17,7 @@ def retry_on_error(func):
                 if ex_str.find("Connection aborted") > -1:
                     retries += 1
                     logger.debug("Connection aborted, retrying {}/{}".format(retries, settings.TWITTERAPI_RETRY))
+                    sleep(.05)
 
                     if retries == settings.TWITTERAPI_RETRY:
                         raise

--- a/traptor/manager/backends/local.py
+++ b/traptor/manager/backends/local.py
@@ -1,6 +1,29 @@
 import os
-from birdy.twitter import AppClient
+from birdy.twitter import AppClient, TwitterClientError
 from traptor import settings
+from api import logger
+
+def retry_on_error(func):
+    def func_wrapper(*args, **kwargs):
+        retries = 0
+
+        while retries < settings.TWITTERAPI_RETRY:
+            try:
+                return func(*args, **kwargs)
+            except TwitterClientError as e:
+                ex_str = str(e)
+                # the TwitterClientError is just a string cast of a lower level exception
+                if ex_str.find("Connection aborted") > -1:
+                    retries += 1
+                    logger.debug("Connection aborted, retrying {}/{}".format(retries, settings.TWITTERAPI_RETRY))
+
+                    if retries == settings.TWITTERAPI_RETRY:
+                        raise
+                else:
+                    raise
+
+            return None
+    return func_wrapper
 
 client = None
 def _get_twitter():
@@ -11,11 +34,13 @@ def _get_twitter():
         client.get_access_token()
     return client
 
+@retry_on_error
 def get_userid_for_username(username):
     _get_twitter()    
     data = client.api.users.show.get(screen_name=username).data
     return data.id_str
 
+@retry_on_error
 def get_recent_tweets_by_keyword(keyword):
     _get_twitter()    
     data = client.api.search.tweets.get(q=keyword, result_type='recent', count=100, include_entities='false').data

--- a/traptor/manager/backends/local.py
+++ b/traptor/manager/backends/local.py
@@ -1,8 +1,16 @@
 import os
 from birdy.twitter import AppClient, TwitterClientError
 from traptor import settings
-from api import logger
 from time import sleep
+from scutils.log_factory import LogFactory
+
+# Initialize Logging
+logger = LogFactory.get_instance(name=os.getenv('LOG_NAME', settings.LOG_NAME),
+            json=os.getenv('LOG_JSON', settings.LOG_JSON) == 'True',
+            stdout=os.getenv('LOG_STDOUT', settings.LOG_STDOUT) == 'True',
+            level=os.getenv('LOG_LEVEL', settings.LOG_LEVEL),
+            dir=os.getenv('LOG_DIR', settings.LOG_DIR),
+            file=os.getenv('LOG_FILE', settings.LOG_FILE))
 
 def retry_on_error(func):
     def func_wrapper(*args, **kwargs):
@@ -24,7 +32,7 @@ def retry_on_error(func):
                 else:
                     raise
 
-            return None
+        return None
     return func_wrapper
 
 client = None
@@ -44,6 +52,6 @@ def get_userid_for_username(username):
 
 @retry_on_error
 def get_recent_tweets_by_keyword(keyword):
-    _get_twitter()    
+    _get_twitter()
     data = client.api.search.tweets.get(q=keyword, result_type='recent', count=100, include_entities='false').data
     return data

--- a/traptor/settings.py
+++ b/traptor/settings.py
@@ -101,6 +101,8 @@ DW_CONFIG = {
     }
 }
 
+TWITTERAPI_RETRY = 3
+
 # Local Overrides
 # ~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
# What's New?

A decorator has been added to retry a request on  "connection aborted" errors (3 times). Unfortunately, Birdy casts the lower exceptions to a string, so they must be detected by a string search of the error messages. All other exceptions are reraised/uncaught, since this PR is only intended to handle transient network errors . 

# Testing

- Ensure that the twitterapi service is setup for local mode, with twitter API keys:
```
- CONSUMER_SECRET={CONSUMER_SECRET}
- CONSUMER_KEY={CONSUMER_KEY}
- API_BACKEND=local
```
- `docker-compose up -d --build twitterapi`
- KW Search
```
curl -X POST \
  http://localhost:5000/v1.0/validate \
  -H 'Content-Type: application/json' \
  -d '{
	"type":"keyword",
	"value":"apple zebra"
}'
```
- Username search
```
curl -X POST \
  http://localhost:5000/v1.0/validate \
  -H 'Content-Type: application/json' \
  -d '{
	"type":"username",
	"value":"apple"
}'
```