### PR TITLE
Integrate traptor with circleci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,7 +39,7 @@ jobs:
             echo $ANSIBLE_VAULT_KEY >> ansible-symphony-ist/vault.passwd
             sed -i 's/control_path/#control_path/g' ansible-symphony-ist/ansible.cfg
             echo '' > ansible-symphony-ist/private_roles/docker-all/meta/main.yaml
-            tar -czpf - ansible-symphony-ist | ssh $ANSIBLE_HOST "mkdir -p $WORKDIR ; tar -xzpf - -C $WORKDIR ; cd ${WORKDIR}/ansible-symphony-ist ; ansible-playbook -i develop.inventory -t site-docker-traptor-all -l docker-traptor-nodes site-docker-infrastructure.yml"
+            tar -czpf - ansible-symphony-ist | ssh -l $ANSIBLE_EXECUTOR_USER $ANSIBLE_EXECUTOR_HOST "mkdir -p $WORKDIR ; tar -xzpf - -C $WORKDIR ; cd ${WORKDIR}/ansible-symphony-ist ; ansible-playbook -i develop.inventory -t site-docker-traptor-all -l docker-traptor-nodes site-docker-infrastructure.yml"
         
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,78 @@
+build_env: &build_env
+  environment:
+    - project_tag: traptor
+    - version_tag: 3.2.4-dev
+    - ansible_branch: develop
+    - ansible_host: tutils@techops-utils.istresearch.com
+version: 2
+jobs:
+  build:
+    <<: *build_env
+    docker:
+      - image: docker
+    steps:
+      - checkout
+      - setup_remote_docker:
+          docker_layer_caching: true
+      - run:
+          name: Build Image
+          command: docker build -t istresearch/${project_tag}:${version_tag} -f Dockerfile .
+      - run: 
+          name: Run Tests
+          command: docker run istresearch/${project_tag}:${version_tag} bash -c 'python -m pytest -vv tests/test_traptor_offline.py'
+      - run:
+          name: Log in to Dockerhub
+          command: docker login -u $DOCKER_USER -p $DOCKER_PASS
+      - run:
+          name: Push Image
+          command: docker push istresearch/${project_tag}:${version_tag}
+  deploy:
+    <<: *build_env
+    docker:
+      - image: docker
+    steps:
+      - run:
+          name: Install dependencies
+          command: |
+            apk add --update bash openssh git
+      - run:
+          name: Configure SSH
+          command: |
+            mkdir -p ~/.ssh
+            chmod 700 ~/.ssh
+            ssh-keyscan -H github.com >> ~/.ssh/known_hosts
+            chmod 600 ~/.ssh/known_hosts
+            echo "Host *" > ~/.ssh/config
+            echo "  StrictHostKeyChecking no" >> ~/.ssh/config
+      - run:
+          name: Clone ansible repo
+          command: git clone -b $ansible_branch git@github.com:istresearch/ansible-symphony-ist.git
+      - run:
+          name: Add vault file
+          command: echo $ANSIBLE_VAULT_KEY >> ansible-symphony-ist/vault.passwd
+      - run:
+          name: Patch ansible control_path
+          command: sed -i 's/control_path/#control_path/g' ansible-symphony-ist/ansible.cfg
+      - run:
+          name: Remove docker-all role dependencies for now
+          command: echo "" > ansible-symphony-ist/private_roles/docker-all/meta/main.yaml
+      - run:
+          name: Run ansible 
+          command: |
+            ssh $ansible_host mkdir -p /tmp/circleci_$project_tag/$CIRCLE_SHA1
+            scp -r ansible-symphony-ist $ansible_host:/tmp/circleci_$project_tag/$CIRCLE_SHA1/ansible-symphony-ist
+            ssh $ansible_host bash <<EOF
+              cd /tmp/circleci_$project_tag/$CIRCLE_SHA1/ansible-symphony-ist 
+              ansible-playbook -i develop.inventory -t site-docker-traptor-all -l docker-traptor-nodes site-docker-infrastructure.yml
+            EOF
+
+workflows:
+  version: 2
+  build_workflow:
+    jobs:
+      - build:
+          context: globalconfig
+      - deploy:
+          context: globalconfig
+          requires:
+            - build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,15 +31,20 @@ jobs:
       - run:
           name: Deploy
           command: |
-            WORKDIR="/tmp/circleci_traptor/${CIRCLE_SHA1}"
-            mkdir -p ~/.ssh
-            echo "Host *" > ~/.ssh/config
-            echo "  StrictHostKeyChecking no" >> ~/.ssh/config
-            git clone -b develop git@github.com:istresearch/ansible-symphony-ist.git
-            echo $ANSIBLE_VAULT_KEY >> ansible-symphony-ist/vault.passwd
-            sed -i 's/control_path/#control_path/g' ansible-symphony-ist/ansible.cfg
-            echo '' > ansible-symphony-ist/private_roles/docker-all/meta/main.yaml
-            tar -czpf - ansible-symphony-ist | ssh -l $ANSIBLE_EXECUTOR_USER $ANSIBLE_EXECUTOR_HOST "mkdir -p $WORKDIR ; tar -xzpf - -C $WORKDIR ; cd ${WORKDIR}/ansible-symphony-ist ; ansible-playbook -i develop.inventory -t site-docker-traptor-all -l docker-traptor-nodes site-docker-infrastructure.yml"
+            BRANCH=${CIRCLE_BRANCH#*/}
+            if [[ $BRANCH == develop ]] || [[ $BRANCH == master ]]; then
+              WORKDIR="/tmp/circleci_traptor/${CIRCLE_SHA1}"
+              mkdir -p ~/.ssh
+              echo "Host *" > ~/.ssh/config
+              echo "  StrictHostKeyChecking no" >> ~/.ssh/config
+              git clone -b develop git@github.com:istresearch/ansible-symphony-ist.git
+              echo $ANSIBLE_VAULT_KEY >> ansible-symphony-ist/vault.passwd
+              sed -i 's/control_path/#control_path/g' ansible-symphony-ist/ansible.cfg
+              tar -czpf - ansible-symphony-ist | ssh -l $ANSIBLE_EXECUTOR_USER $ANSIBLE_EXECUTOR_HOST "mkdir -p $WORKDIR ; tar -xzpf - -C $WORKDIR" 
+              ssh -l $ANSIBLE_EXECUTOR_USER $ANSIBLE_EXECUTOR_HOST "cd ${WORKDIR}/ansible-symphony-ist ; ansible-playbook -i develop.inventory -t site-docker-traptor-all -l docker-traptor-nodes site-docker-infrastructure.yml"
+            else
+              echo "Skipping deploy step"
+            fi
         
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -63,7 +63,7 @@ jobs:
             scp -r ansible-symphony-ist $ansible_host:/tmp/circleci_$project_tag/$CIRCLE_SHA1/ansible-symphony-ist
             ssh $ansible_host bash <<EOF
               cd /tmp/circleci_$project_tag/$CIRCLE_SHA1/ansible-symphony-ist 
-              ansible-playbook -i develop.inventory -t site-docker-traptor-all -l docker-traptor-nodes site-docker-infrastructure.yml
+              ansible-playbook -i develop.inventory -t site-docker-traptor-all -l docker-traptor-nodes -e traptor_tag=$version_tag site-docker-infrastructure.yml
             EOF
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,13 +1,6 @@
-build_env: &build_env
-  environment:
-    - project_tag: traptor
-    - version_tag: 3.2.4dev
-    - ansible_branch: develop
-    - ansible_host: tutils@techops-utils.istresearch.com
 version: 2
 jobs:
-  build:
-    <<: *build_env
+  run:
     docker:
       - image: docker
     steps:
@@ -15,64 +8,43 @@ jobs:
       - setup_remote_docker:
           docker_layer_caching: true
       - run:
-          name: Build Image
-          command: docker build -t istresearch/${project_tag}:${version_tag} -f Dockerfile .
-      - run: 
-          name: Run Tests
-          command: docker run istresearch/${project_tag}:${version_tag} bash -c 'python -m pytest -vv tests/test_traptor_offline.py'
-      - run:
-          name: Log in to Dockerhub
-          command: docker login -u $DOCKER_USER -p $DOCKER_PASS
-      - run:
-          name: Push Image
-          command: docker push istresearch/${project_tag}:${version_tag}
-  deploy:
-    <<: *build_env
-    docker:
-      - image: docker
-    steps:
-      - run:
-          name: Install dependencies
+          name: Build 
           command: |
-            apk add --update bash openssh git
+            apk add --update python openssh git
+            IMAGE_BASE=istresearch/traptor
+            DOCKER_CI_IMAGE_TAG="${IMAGE_BASE}:ci-develop"
+            BRANCH=${CIRCLE_BRANCH#*/}
+            VERSION=`python traptor/version.py`
+            if [[ ! -z $CIRCLE_TAG ]]; then
+              VERSION_TAG="${VERSION}"
+            elif [[ $BRANCH == develop ]]; then
+              VERSION_TAG="${VERSION}-dev"
+            else
+              VERSION_TAG="ci-${VERSION}-${BRANCH}"
+            fi
+            DOCKER_IMAGE_TAG="${IMAGE_BASE}:${VERSION_TAG}"
+            docker build -t $DOCKER_CI_IMAGE_TAG -t $DOCKER_IMAGE_TAG -f Dockerfile .
+            docker run $DOCKER_CI_IMAGE_TAG bash -c 'python -m pytest -vv tests/test_traptor_offline.py'
+            docker login -u $DOCKER_USER -p $DOCKER_PASS
+            docker push $DOCKER_CI_IMAGE_TAG
+            docker push $DOCKER_IMAGE_TAG
       - run:
-          name: Configure SSH
+          name: Deploy
           command: |
+            WORKDIR="/tmp/circleci_traptor/${CIRCLE_SHA1}"
             mkdir -p ~/.ssh
-            chmod 700 ~/.ssh
-            ssh-keyscan -H github.com >> ~/.ssh/known_hosts
-            chmod 600 ~/.ssh/known_hosts
             echo "Host *" > ~/.ssh/config
             echo "  StrictHostKeyChecking no" >> ~/.ssh/config
-      - run:
-          name: Clone ansible repo
-          command: git clone -b $ansible_branch git@github.com:istresearch/ansible-symphony-ist.git
-      - run:
-          name: Add vault file
-          command: echo $ANSIBLE_VAULT_KEY >> ansible-symphony-ist/vault.passwd
-      - run:
-          name: Patch ansible control_path
-          command: sed -i 's/control_path/#control_path/g' ansible-symphony-ist/ansible.cfg
-      - run:
-          name: Remove docker-all role dependencies for now
-          command: echo "" > ansible-symphony-ist/private_roles/docker-all/meta/main.yaml
-      - run:
-          name: Run ansible 
-          command: |
-            ssh $ansible_host mkdir -p /tmp/circleci_$project_tag/$CIRCLE_SHA1
-            scp -r ansible-symphony-ist $ansible_host:/tmp/circleci_$project_tag/$CIRCLE_SHA1/ansible-symphony-ist
-            ssh $ansible_host bash <<EOF
-              cd /tmp/circleci_$project_tag/$CIRCLE_SHA1/ansible-symphony-ist 
-              ansible-playbook -i develop.inventory -t site-docker-traptor-all -l docker-traptor-nodes -e traptor_tag=$version_tag site-docker-infrastructure.yml
-            EOF
-
+            git clone -b develop git@github.com:istresearch/ansible-symphony-ist.git
+            echo $ANSIBLE_VAULT_KEY >> ansible-symphony-ist/vault.passwd
+            sed -i 's/control_path/#control_path/g' ansible-symphony-ist/ansible.cfg
+            echo '' > ansible-symphony-ist/private_roles/docker-all/meta/main.yaml
+            tar -czpf - ansible-symphony-ist | ssh $ANSIBLE_HOST "mkdir -p $WORKDIR ; tar -xzpf - -C $WORKDIR ; cd ${WORKDIR}/ansible-symphony-ist ; ansible-playbook -i develop.inventory -t site-docker-traptor-all -l docker-traptor-nodes site-docker-infrastructure.yml"
+        
 workflows:
   version: 2
-  build_workflow:
+  pipeline:
     jobs:
-      - build:
+      - run:
           context: globalconfig
-      - deploy:
-          context: globalconfig
-          requires:
-            - build
+

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 build_env: &build_env
   environment:
     - project_tag: traptor
-    - version_tag: 3.2.4-dev
+    - version_tag: 3.2.4dev
     - ansible_branch: develop
     - ansible_host: tutils@techops-utils.istresearch.com
 version: 2


### PR DESCRIPTION
This PR allows Circle CI to build, test, upload, and deploy a docker image. 

Testing

Circle CI is currently configured to only build this project for open PRs; you can trigger a build by committing to this branch (eg `git commit --allow-empty -m "ping circleci" && git push`) 