### PR TITLE
Use specific docker version to avoid login bug

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   run:
     docker:
-      - image: docker
+      - image: docker:18.03.0
     steps:
       - checkout
       - setup_remote_docker:


### PR DESCRIPTION
A [recent commit](https://github.com/docker/cli/commit/4290df395808d1780afcb1a4c2656497050d5fae#commitcomment-28547505) to the docker cli has caused our CircleCI pipeline to break. This PR sets the docker image used in CircleCI to a version before the behavior was introduced.