### PR TITLE
PULSE 5348 - Fixing geo validation

### DIFF
--- a/traptor/manager/api.py
+++ b/traptor/manager/api.py
@@ -1,6 +1,7 @@
 import dateutil.parser as parser
 import os
 import traceback
+import json
 from functools import wraps
 from dog_whistle import dw_config, dw_callback
 from scutils.log_factory import LogFactory
@@ -33,7 +34,12 @@ def validate(rule):
         if rule['type'] in ('keyword', 'hashtag'):
             result = _validate_track_rule(rule['value'])
         if rule['type'] in ('geo',):
-            result = _validate_geo_rule(rule['value'])
+            try:
+                value = json.loads(rule.get('metadata', {}).get('complex_value', ''))
+            except Exception:
+                value = rule['value']
+
+            result = _validate_geo_rule(value)
         for kk in result:
             response[kk] = result[kk]
         status_code = 200 if result['status'] == 'ok' else 500


### PR DESCRIPTION
Aligning geo validation with rest of system, to avoid the simple string value.

**Testing**
1) Start the twitterapi using this docker-compose-twitterapi.yml:
```
version: '2'
services:
  twitterapi:
    build: .
    command: bash -c "cd traptor/manager ; uwsgi --http :5000 -p 1 -w wsgi"
    environment:
      - API_BACKEND=local
      - CONSUMER_SECRET=<secret>
      - CONSUMER_KEY=<key>
      - LOG_NAME=twitterapi
      - LOG_DIR=/var/log/twitterapi
      - LOG_FILE=twitterapi.log
      - LOG_STDOUT=False
      - LOG_JSON=True
      - LOG_LEVEL=DEBUG
    ports:
      - "5000:5000"
    volumes:
      - ./logs:/var/log/twitterapi
    restart: always
```

2. Validate a geo rule:
```
$ curl -XPOST -H "content-type:application/json" "http://localhost:5000/v1.0/validate" -d'
{
        "metadata": {
          "complex_value": "{\"type\":\"Feature\",\"properties\":{},\"geometry\":{\"type\":\"Polygon\",\"coordinates\":[[[0.0,0.1],[0.0,0.3],[0.2,0.3],[0.2,0.1]]]}}"
        },
        "type": "geo",
        "value": "0.0 0.1 0.2 0.3"
}' -i
```
It should succeed, whereas before this change you would receive a nondescript tuple unpacking error because it was attempting to split the string value on `,`. Nowhere else in the system are we actually relying on the simple string value, so this brings it up to spec.