### PR TITLE
Pulse 4299 - Traptor connectivity monitors

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,6 +26,26 @@ services:
       - DW_STATSD_PORT=8125 # port statsd container is listening on
     restart: always
 
+  healthcheck:
+    build: .
+    volumes:
+      - .:/code
+      - ./logs:/var/log/traptor
+    env_file:
+      - ./traptor.env
+    depends_on:
+      - redis
+    command: ["python2", "traptor/healthcheck.py"]
+    environment:
+      - REDIS_HOST=redis
+      - REDIS_PORT=6379
+      - REDIS_DB=2
+      - DW_ENABLED=True
+      - DW_LOCAL=True # True for local dev
+      - DW_STATSD_HOST=statsd # on a linux host set to 172.17.0.1 and on mac os host set to docker.for.mac.localhost
+      - DW_STATSD_PORT=8125 # port statsd container is listening on
+    restart: always
+
   redis:
     image: redis:2.8.17
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,7 @@ services:
 
   traptor:
     build: .
+    image: istresearch/traptor
     volumes:
       - .:/code
       - ./logs:/var/log/traptor
@@ -27,7 +28,7 @@ services:
     restart: always
 
   healthcheck:
-    build: .
+    image: istresearch/traptor
     volumes:
       - .:/code
       - ./logs:/var/log/traptor

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,13 +38,19 @@ services:
       - redis
     command: ["python2", "traptor/healthcheck.py"]
     environment:
+      - KAFKA_HOSTS=kafka:9092
+      - KAFKA_TOPIC=traptor
       - REDIS_HOST=redis
       - REDIS_PORT=6379
       - REDIS_DB=2
       - DW_ENABLED=True
-      - DW_LOCAL=True # True for local dev
-      - DW_STATSD_HOST=statsd # on a linux host set to 172.17.0.1 and on mac os host set to docker.for.mac.localhost
+      - DW_LOCAL=False # True for local dev
+      - LOG_STDOUT=True # True for local dev
+      - DW_STATSD_HOST=172.17.0.1 # on a linux host set to 172.17.0.1 and on mac os host set to docker.for.mac.localhost
       - DW_STATSD_PORT=8125 # port statsd container is listening on
+      - HEALTHCHECK_REDIS_SLEEP=30
+      - HEALTHCHECK_KAFKA_SLEEP=30
+      - HEALTHCHECK_TWITTER_SLEEP=60
     restart: always
 
   redis:

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,3 +20,4 @@ scutils==1.3.0dev2
 tenacity>=4.0.1,<=4.3
 urllib3==1.21.1
 uwsgi==2.0.15
+pykafka==2.6.0

--- a/traptor/healthcheck.py
+++ b/traptor/healthcheck.py
@@ -1,0 +1,122 @@
+import redis
+import settings
+import time
+import signal
+import os
+import traceback
+import socket
+
+from threading import Thread
+from scutils.log_factory import LogFactory
+from dog_whistle import dw_config, dw_callback
+from pykafka import KafkaClient
+from apiclient.discovery import build
+from apiclient.errors import HttpError
+
+
+class HealthCheck:
+    running = True
+    logger = None
+
+    redis_thread = None
+    kafka_thread = None
+
+    def __init__(self):
+        self.logger = LogFactory.get_instance(json=os.getenv('LOG_JSON', 'True') == 'True',
+                                         name=os.getenv('LOG_NAME', 'traptor-healthcheck'),
+                                         stdout=os.getenv('LOG_STDOUT', 'False') == 'True',
+                                         level=os.getenv('LOG_LEVEL', 'INFO'),
+                                         dir=os.getenv('LOG_DIR', 'logs'),
+                                         file=os.getenv('LOG_FILE', 'traptor-healthcheck.log'))
+
+        # Set the default timeout for all sockets
+        socket.setdefaulttimeout(int(settings.HEALTHCHECK_TIMEOUT))
+
+        if settings.DW_ENABLED:
+            self.logger.debug("Enabling dogwhistle")
+            dw_config(settings.DW_SETTINGS)
+            self.logger.register_callback('>=INFO', dw_callback)
+
+        signal.signal(signal.SIGINT, self.close)
+        signal.signal(signal.SIGTERM, self.close)
+
+    def _check_redis(self):
+        redis_client = None
+
+        while self.running:
+            try:
+                self.logger.info('checking_redis')
+
+                if redis_client is None:
+                    redis_client = redis.Redis(host=os.getenv('REDIS_HOST', settings.REDIS_HOST),
+                                         port=os.getenv('REDIS_PORT', settings.REDIS_PORT),
+                                         db=os.getenv('REDIS_DB', settings.REDIS_DB))
+
+                if redis_client.ping():
+                    self.logger.info('redis_ping')
+                else:
+                    self.logger.error('redis_ping_error')
+            except Exception as ex:
+                redis_client = None
+                self.logger.error('redis_ping_error',
+                                  extra={"exception": str(ex),
+                                         "ex": traceback.format_exc()})
+
+            time.sleep(int(settings.HEALTHCHECK_REDIS_SLEEP))
+
+    def _check_kafka(self):
+        kafka_client = None
+
+        while self.running:
+            try:
+                self.logger.info('checking_kafka')
+
+                if kafka_client is None:
+                    kafka_client = KafkaClient(hosts=os.getenv('KAFKA_HOSTS', settings.KAFKA_HOSTS))
+                    topic = kafka_client.topics[os.getenv('KAFKA_TOPIC', settings.KAFKA_TOPIC)]
+                else:
+                    kafka_client.update_cluster()
+
+                if kafka_client:
+                    self.logger.info('kafka_ping')
+                else:
+                    self.logger.info('kafka_ping_error')
+
+            except Exception as ex:
+                #reset kafka so we can try to reopen it!
+                kafka_client = None
+                self.logger.error('kafka_ping_error',
+                                  extra={"exception": str(ex),
+                                         "ex": traceback.format_exc()})
+
+            time.sleep(int(settings.HEALTHCHECK_KAFKA_SLEEP))
+
+    def run(self):
+        self.logger.debug('Waiting before starting, to let kafka/redis in catch up')
+        time.sleep(10)
+
+        if int(settings.HEALTHCHECK_REDIS_SLEEP) > 0:
+            self.redis_thread = Thread(target=self._check_redis)
+            self.redis_thread.setDaemon(True)
+            self.redis_thread.start()
+
+        if int(settings.HEALTHCHECK_KAFKA_SLEEP) > 0:
+            self.kafka_thread = Thread(target=self._check_kafka)
+            self.kafka_thread.setDaemon(True)
+            self.kafka_thread.start()
+
+        heartbeat_period = int(settings.HEARTBEAT_PERIOD)
+        if heartbeat_period < 1:
+            heartbeat_period = 30
+
+        while self.running:
+            self.logger.info('heartbeat')
+            time.sleep(heartbeat_period)
+
+    def close(self, signum, frame):
+        self.logger.info('closing')
+        self.running = False
+
+
+if __name__ == '__main__':
+    HealthCheck().run()

--- a/traptor/healthcheck.py
+++ b/traptor/healthcheck.py
@@ -35,7 +35,14 @@ class HealthCheck:
 
         if settings.DW_ENABLED:
             self.logger.debug("Enabling dogwhistle")
-            dw_config(settings.DW_CONFIG)
+            default_tags = {
+                "tags": [
+                    "traptor_type:{}".format(os.getenv('TRAPTOR_TYPE')),
+                    "traptor_id:{}".format(os.getenv('TRAPTOR_ID'))
+                ]
+            }
+            dw_settings = dict(settings.DW_CONFIG.items() + default_tags.items())
+            dw_config(dw_settings)
             self.logger.register_callback('>=INFO', dw_callback)
 
         signal.signal(signal.SIGINT, self.close)

--- a/traptor/settings.py
+++ b/traptor/settings.py
@@ -91,6 +91,8 @@ DW_CONFIG = {
         'gauges': [
             (DWG_RULE_COUNT['name'], DWG_RULE_COUNT['key'], DWG_RULE_COUNT['value']),
             (DWG_MATCH_COUNT['name'], DWG_MATCH_COUNT['key'], DWG_MATCH_COUNT['value']),
+            ('redis_ping_status', 'redis_ping_status', 'status.int'),
+            ('kafka_ping_status', 'kafka_ping_status', 'status.int'),
         ]
     },
     'allow_extra_tags': True,
@@ -102,6 +104,11 @@ DW_CONFIG = {
 }
 
 TWITTERAPI_RETRY = 3
+
+HEALTHCHECK_TIMEOUT = os.getenv('HEALTHCHECK_TIMEOUT', 10)
+HEARTBEAT_PERIOD = int(os.getenv('HEARTBEAT_PERIOD', 100))
+HEALTHCHECK_REDIS_SLEEP = os.getenv('HEALTHCHECK_REDIS_SLEEP', 30)
+HEALTHCHECK_KAFKA_SLEEP = os.getenv('HEALTHCHECK_KAFKA_SLEEP', 30)
 
 # Local Overrides
 # ~~~~~~~~~~~~~~~

--- a/traptor/settings.py
+++ b/traptor/settings.py
@@ -93,6 +93,7 @@ DW_CONFIG = {
             (DWG_MATCH_COUNT['name'], DWG_MATCH_COUNT['key'], DWG_MATCH_COUNT['value']),
             ('redis_ping_status', 'redis_ping_status', 'status.int'),
             ('kafka_ping_status', 'kafka_ping_status', 'status.int'),
+            ('twitter_ping_status', 'twitter_ping_status', 'status.int'),
         ]
     },
     'allow_extra_tags': True,
@@ -109,6 +110,7 @@ HEALTHCHECK_TIMEOUT = os.getenv('HEALTHCHECK_TIMEOUT', 10)
 HEARTBEAT_PERIOD = int(os.getenv('HEARTBEAT_PERIOD', 100))
 HEALTHCHECK_REDIS_SLEEP = os.getenv('HEALTHCHECK_REDIS_SLEEP', 30)
 HEALTHCHECK_KAFKA_SLEEP = os.getenv('HEALTHCHECK_KAFKA_SLEEP', 30)
+HEALTHCHECK_TWITTER_SLEEP = os.getenv('HEALTHCHECK_TWITTER_SLEEP', 30)
 
 # Local Overrides
 # ~~~~~~~~~~~~~~~


### PR DESCRIPTION
Instructions incoming

This PR adds connectivity monitoring capability to Traptor. The following services are monitored:

* Redis
* Kafka
* Twitter streaming API

## Testing

### 1) Start up your local datadog agent.

Ubuntu:

    $ sudo service datadog-agent start

OS X:

    $ sudo datadog-agent start

### 2) Update environment variables

Either create a `traptor.env` file in the root directory of this project with the necessary env vars or update the `healthcheck` service in the docker-compose.yml file.

```
TRAPTOR_TYPE=
TRAPTOR_ID=
RULE_CHECK_INTERVAL=
USE_SENTRY=
SENTRY_URL=
LOG_LEVEL=
LOG_DIR=
LOG_FILE_NAME=
KAFKA_ENABLED=
KAFKA_HOSTS=
KAFKA_TOPIC=
REDIS_HOST=
REDIS_PORT=
REDIS_DB=
REDIS_PUBSUB_CHANNEL=
CONSUMER_KEY=
CONSUMER_SECRET=
ACCESS_TOKEN=
ACCESS_TOKEN_SECRET=
```

Under the `healthcheck` service in the docker-compose.yml file, update the `STATSD_HOST` to be the appropriate value based on your operating system. 

### 3) Bring up the compose stack

Check out this branch

    $ git checkout --track origin/PULSE-4299

Bring up traptor along with the new traptor healthcheck service

    $ docker-compose up --build -d

### 4) Check DataDog for Metrics

After a couple of minutes, in the [DataDog Metric Explorer](https://app.datadoghq.com/metric/explorer) the following metrics should appear:

* `traptor.twitter_ping_status`
* `traptor.redis_ping_status`
* `traptor.kafka_ping_status`

With proper keys and connection information provided, the value of each of these metrics should be 1.

To verify the values of the metrics change in response to outages, individually disable a service and observe the value of the corresponding metric in the DataDog metric explorer.

For example, to stop the redis service:

    $ docker-compose stop redis

After observing the graph go to 0 for `traptor.redis_ping_status` you can then start the container again with

    $ docker-compose start redis

To test the Twitter API, you can intentionally enter an incorrect API key and restart the healthcheck container.