### PR TITLE
PULSE 6262 - Fixed swagger spec

### DIFF
--- a/traptor/manager/spec.yml
+++ b/traptor/manager/spec.yml
@@ -32,9 +32,7 @@ paths:
                   - 'keyword'
                   - 'username'
               value:
-                type: 
-                  - string
-                  - object
+                type: object
       responses:
         200:
           description: Success


### PR DESCRIPTION
The swagger spec only permits a single type for a parameter. The `validate()` function expects a dict parameter, so we are using `object` in the spec.