### PR TITLE
P4 1881 - Traptor Connection Exception Handling

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,10 +18,13 @@ services:
 #      - logstash
 #      - kibana
     environment:
+      - KAFKA_HOSTS=kafka:9092
       - REDIS_HOST=redis
       - REDIS_PORT=6379
-      - REDIS_DB=2
-      - DW_ENABLED=True
+      - REDIS_DB=1
+      - HEARTBEAT_INTERVAL=10
+      - LOG_STDOUT=True
+      - DW_ENABLED=False
       - DW_LOCAL=True # True for local dev
       - DW_STATSD_HOST=statsd # on a linux host set to 172.17.0.1 and on mac os host set to docker.for.mac.localhost
       - DW_STATSD_PORT=8125 # port statsd container is listening on
@@ -42,7 +45,7 @@ services:
       - KAFKA_TOPIC=traptor
       - REDIS_HOST=redis
       - REDIS_PORT=6379
-      - REDIS_DB=2
+      - REDIS_DB=1
       - DW_ENABLED=True
       - DW_LOCAL=False # True for local dev
       - LOG_STDOUT=True # True for local dev
@@ -50,7 +53,7 @@ services:
       - DW_STATSD_PORT=8125 # port statsd container is listening on
       - HEALTHCHECK_REDIS_SLEEP=30
       - HEALTHCHECK_KAFKA_SLEEP=30
-      - HEALTHCHECK_TWITTER_SLEEP=60
+      - HEALTHCHECK_TWITTER_SLEEP=600
     restart: always
 
   redis:
@@ -59,17 +62,18 @@ services:
       - "6379:6379"
 
   kafka:
-    image: wurstmeister/kafka
+    image: wurstmeister/kafka:0.9.0.1-1
     ports:
       - "9092:9092"
     environment:
-      KAFKA_ADVERTISED_HOST_NAME: 192.168.99.100
+      KAFKA_ADVERTISED_HOST_NAME: kafka
       KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
-      OFFSETS_TOPIC_REPLICATION_FACTOR: 1
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
     depends_on:
       - zookeeper
+    restart: always
 
   zookeeper:
     image: wurstmeister/zookeeper
@@ -127,13 +131,16 @@ services:
 
   twitterapi:
     build: .
+    env_file:
+      - ./traptor.env
     environment:
       - LOG_NAME=twitterapi
       - LOG_DIR=/var/log/twitterapi
       - LOG_FILE=twitterapi.log
-      - LOG_STDOUT=False
+      - LOG_STDOUT=True
       - LOG_JSON=True
-      - LOG_LEVEL=DEBUG
+      - LOG_LEVEL=INFO
+      - API_BACKEND=local
     ports:
       - "5000:5000"
     volumes:

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ click==6.6
 connexion==1.1.10
 datadog==0.14.0
 dog-whistle==0.5.0
-kafka-python==1.3.1
+kafka-python==1.4.2
 mockredispy==2.9.3
 nose==1.3.7
 pymysql==0.7.2

--- a/tests/test_traptor_offline.py
+++ b/tests/test_traptor_offline.py
@@ -239,23 +239,23 @@ class TestTraptor(object):
         traptor._setup()
         # mock response
         data = {'data': traptor.traptor_type + ':' + str(traptor.traptor_id)}
-        pubsub = MagicMock()
-        pubsub.subscribe = MagicMock()
-        pubsub.listen = MagicMock(return_value=[data])
-        pubsub.close = MagicMock()
-        traptor.pubsub_conn = MagicMock()
 
         def stop_after(*args, **kwargs):
             traptor.exit = True
-            return pubsub
+            return data
 
-        traptor.pubsub_conn.pubsub = MagicMock(side_effect=stop_after)
+        pubsub = MagicMock()
+        pubsub.subscribe = MagicMock()
+        pubsub.get_message = MagicMock(side_effect=stop_after)
+        pubsub.close = MagicMock()
+        traptor.pubsub_conn = MagicMock()
+        traptor.pubsub_conn.pubsub = MagicMock(return_value=pubsub)
 
         traptor._listenToRedisForRestartFlag()
         restart_flag = traptor._getRestartSearchFlag()
         assert restart_flag == True
         assert pubsub.subscribe.call_count == 1
-        assert pubsub.listen.call_count == 1
+        assert pubsub.get_message.call_count == 1
         assert pubsub.close.call_count == 1
 
     def test_redis_rules(self, redis_rules, traptor):

--- a/traptor/healthcheck.py
+++ b/traptor/healthcheck.py
@@ -117,7 +117,7 @@ class HealthCheck:
                 self.logger.info('checking_twitter')
 
                 if twitter_stream is None:
-		    twitter_client = StreamClient(
+                    twitter_client = StreamClient(
                         os.getenv('CONSUMER_KEY'),
                         os.getenv('CONSUMER_SECRET'),
                         os.getenv('ACCESS_TOKEN'),

--- a/traptor/settings.py
+++ b/traptor/settings.py
@@ -86,7 +86,8 @@ DW_CONFIG = {
             ('tweet_to_kafka_failure', 'src.tweet_to_kafka.failure'),
             ('limit_message_received', 'src.limit.messages.count'),
             ('limit_message_count', 'src.limit.current_limited'),
-            ('Stream keep-alive received', 'src.twitter.keepalive')
+            ('Stream keep-alive received', 'src.twitter.keepalive'),
+            ('Waiting for rules', 'src.rules.waiting')
         ],
         'gauges': [
             (DWG_RULE_COUNT['name'], DWG_RULE_COUNT['key'], DWG_RULE_COUNT['value']),

--- a/traptor/settings.py
+++ b/traptor/settings.py
@@ -87,7 +87,11 @@ DW_CONFIG = {
             ('limit_message_received', 'src.limit.messages.count'),
             ('limit_message_count', 'src.limit.current_limited'),
             ('Stream keep-alive received', 'src.twitter.keepalive'),
-            ('Waiting for rules', 'src.rules.waiting')
+            ('Waiting for rules', 'src.rules.waiting'),
+            ('Withholding heartbeat, not accepting rule assignments', 'src.rules.not_accepting'),
+            ('API credentials are invalid', 'src.auth.invalid'),
+            ('Exception caught in redis pub/sub listener, restarting listener', 'src.redis.error'),
+            ('Exception caught closing redis pub/sub listener', 'src.redis.error')
         ],
         'gauges': [
             (DWG_RULE_COUNT['name'], DWG_RULE_COUNT['key'], DWG_RULE_COUNT['value']),

--- a/traptor/traptor.py
+++ b/traptor/traptor.py
@@ -55,18 +55,8 @@ class retry_if_exception_type_with_caveat(retry_if_exception):
         self.exception_types = exception_types
         self.excluding_types = excluding
 
-        def p(e):
-            et = type(e)
-
-            if isinstance(e, exception_types):
-                if not isinstance(e, excluding):
-                    return True
-            return False
-
-
         super(retry_if_exception_type_with_caveat, self).__init__(
-            p
-            #lambda e: isinstance(e, exception_types) and not isinstance(e, excluding)
+            lambda e: isinstance(e, exception_types) and not isinstance(e, excluding)
         )
 
 

--- a/traptor/traptor.py
+++ b/traptor/traptor.py
@@ -1295,13 +1295,10 @@ class Traptor(object):
         # Get the list of rules from Redis
         self.redis_rules = [rule for rule in self._get_redis_rules()]
 
-        if len(self.redis_rules) == 0:
-            self.logger.info('Waiting for rules', extra=logExtra())
-
         # If there are no rules assigned to this Traptor, simma down and wait a minute
         while len(self.redis_rules) == 0:
-            self.logger.debug('No Redis rules assigned', extra=logExtra({
-                    'sleep_seconds': self.rule_check_interval
+            self.logger.info('Waiting for rules', extra=logExtra({
+                'sleep_seconds': self.rule_check_interval
             }))
             time.sleep(self.rule_check_interval)
             self.redis_rules = [rule for rule in self._get_redis_rules()]
@@ -1339,7 +1336,7 @@ class Traptor(object):
         self.logger.debug("Heartbeat started. Now to check for the rules")
 
         # Do all the things
-        while True:
+        while True: # TODO Ensure we handle clean exits on signal
             self._delete_rule_counters()
             self._wait_for_rules()
 

--- a/traptor/traptor.py
+++ b/traptor/traptor.py
@@ -468,7 +468,7 @@ class Traptor(object):
     @retry(
         wait=wait_incrementing(60, 60, 300),
         stop=stop_never,
-        retry=retry_if_exception_type_with_caveat((BirdyException, TwitterApiError), excluding=TwitterAuthError),
+        retry=retry_if_exception_type_with_caveat(BirdyException, excluding=TwitterAuthError),
         reraise=True,
         after=log_retry_twitter,
     )
@@ -1181,14 +1181,14 @@ class Traptor(object):
 
                 pubsub = self.pubsub_conn.pubsub(ignore_subscribe_messages=True)
                 pubsub.subscribe(self.traptor_notify_channel)
-                # listen() is a generator that blocks until a message is available
+
                 while not self.exit:
-                #for msg in pubsub.listen():
                     msg = pubsub.get_message(timeout=1)
                     if msg is not None:
                         data = str(msg['data'])
                         t = data.split(':')
                         self.logger.debug('PubSub', extra=logExtra(t))
+
                         if t[0] == self.traptor_type and t[1] == str(self.traptor_id):
                             # Restart flag found for our specific instance
                             self._setRestartSearchFlag(True)


### PR DESCRIPTION
# For the Reviewer
- [x] Code review complete
- [x] Testing Complete
- [ ] Quality ORT App Documentation Updated (your name is in the Validator square for this feature)

When this is complete, you should approve the PR via github.

# For the Reviewee

<Reminder PR Title should be JIRA_NUMBER and Useful Description>

## Summary
Re-implemented handling of Twitter connection exceptions. All BirdyExceptions are retried with a linear backoff starting at 60s, accumulating 60s each retry, for a max wait of 5 min to respect Twitter's back-off message and preserve our API quota. TwitterAuthError exceptions put the Traptor into an idle state and turn off it's heartbeat so that it's rules are reallocated to other functional Traptor instances. 

Other changes include signal handling and cleanup for all resources during shutdown. Additional Datadog metrics to improve monitoring of Traptor is also included.

#### Release Note
Re-implemented handling of Twitter connection exceptions.

#### Breaking Changes
<Description for Techops of how to handle changes, migrations, updates>None.

## Quality Assurance

You have gathered the following items:
- [x] This PR is tagged with a Release Milestone
- [ ] You have a log message clearly identifying when this feature is **working successfully**
- [ ] You have a log message clearly identifying when this feature is **failing**
- [ ] You added a PR against [p4-alerting](https://github.com/istresearch/p4-alerting/) to trigger based on the failure condition above

Given all of the items above, you have updated your Application ORT at the following locations:
- **Features and Alerting**: <link to app ORT>Required.
- **P4 Alerting**: <link to p4-alerting PR>Required.

## Testing and Verification

1. Run stacks for Cooper and Traptor Rule Manager (docker-compose-2.yml): Cooper web and engine, Traptor RM, elasticsearch 7.8

2. Configure a `traptor.env` with valid Twitter credentials.

3. Run the Traptor dependencies: redis, kafka, twitterapi

4. Start traptor: `docker-compose up --build traptor`

5. Traptor should start up and begin waiting for rules. Kill Traptor `ctrl-c` to ensure it shuts down cleanly and quickly.

6. Start Traptor again. Activate a Cooper rule:
```
 $ curl -XPOST -H "content-type:application/json" "localhost:8080/cooper/rule" -d'{"type":"keyword", "value":"soccer"}'
```

7. Rule manager should process the rule and assign it to the Traptor. Traptor should receive a restart notification and initiate a Birdy connection to collect.

8. Restart Traptor many times. Let it run long enough to connect to Twitter, then immediately restart it again until you receive a `TwitterRateLimitError`. Once the error is recceived, leave Traptor running. Traptor should wait a full minute before retrying the connection. It should succeed.

9. Stop Traptor. Alter the API credentials to make them invalid. Start Traptor and wait for rule manager to assign the collection rule.

10. Traptor should receive a `TwitterAuthError` and enter an idle mode. The auth error should be logged once a minute. Also, the heartbeat should stop letting rule manager know to reassign the rules away. Watch the rule manager logs for this.
