### PR TITLE
P4 2619 - Rule Matching Unicode Exception

### DIFF
--- a/tests/test_traptor_offline.py
+++ b/tests/test_traptor_offline.py
@@ -1,3 +1,4 @@
+# coding=utf-8
 """Traptor unit tests."""
 # To run with autotest and coverage and print all output to console run:
 #   py.test -s --cov=traptor --looponfail tests/
@@ -346,37 +347,43 @@ class TestTraptor(object):
 
         traptor.twitter_rules = traptor._make_twitter_rules([
             {
-                "rule_id": "1",
-                "value": "happy",
-                "rule_type": "track",
-                "orig_type": "keyword"
+                "rule_id": u"1",
+                "value": u"happy",
+                "rule_type": u"track",
+                "orig_type": u"keyword"
             },
             {
-                "rule_id": "2",
-                "value": "summer",
-                "rule_type": "track",
-                "orig_type": "hashtag"
+                "rule_id": u"2",
+                "value": u"summer",
+                "rule_type": u"track",
+                "orig_type": u"hashtag"
             },
             {
-                "rule_id": "3",
-                "value": "#apple",
-                "rule_type": "track",
-                "orig_type": "hashtag"
+                "rule_id": u"3",
+                "value": u"#apple",
+                "rule_type": u"track",
+                "orig_type": u"hashtag"
             },
             {
-                "rule_id": "4",
-                "value": "#sliding door",
-                "rule_type": "track",
-                "orig_type": "hashtag"
+                "rule_id": u"4",
+                "value": u"#sliding door",
+                "rule_type": u"track",
+                "orig_type": u"hashtag"
             },
             {
-                "rule_id": "5",
-                "value": "summer",
-                "rule_type": "track",
-                "orig_type": "hashtag"
+                "rule_id": u"5",
+                "value": u"summer",
+                "rule_type": u"track",
+                "orig_type": u"hashtag"
+            },
+            {
+                "rule_id": u"6",
+                "value": u"今日中国",
+                "rule_type": u"track",
+                "orig_type": u"keyword"
             }])
 
-        assert traptor.twitter_rules == '#apple,#sliding #door,#summer,happy'
+        assert traptor.twitter_rules == u'#apple,#sliding #door,#summer,今日中国,happy'
 
     # Tweet Enrichments
 

--- a/tests/test_traptor_offline.py
+++ b/tests/test_traptor_offline.py
@@ -383,7 +383,10 @@ class TestTraptor(object):
                 "orig_type": u"keyword"
             }])
 
-        assert traptor.twitter_rules == u'#apple,#sliding #door,#summer,今日中国,happy'
+        given_set = set(traptor.twitter_rules.split(','))
+        expected_set = set(u'#apple,#sliding #door,#summer,今日中国,happy'.split(','))
+        assert len(given_set.difference(expected_set)) == 0
+        assert len(expected_set.difference(given_set)) == 0
 
     # Tweet Enrichments
 

--- a/traptor/rule_set.py
+++ b/traptor/rule_set.py
@@ -155,7 +155,8 @@ class RuleSet(object):
         for rule in other:
             self.remove(rule.get('rule_id'))
 
-    def get_normalized_value(self, rule):
+    @staticmethod
+    def get_normalized_value(rule):
         """
         Normalize the rule value to ensure correct assignment.
         :param rule: A rule dictionary.

--- a/traptor/traptor.py
+++ b/traptor/traptor.py
@@ -1372,7 +1372,7 @@ class Traptor(object):
         if 'traptor' in enriched_data and 'collection_rules' in enriched_data['traptor']:
             for rule in enriched_data['traptor']['collection_rules']:
                 if 'value' in rule:
-                    rule_values.add(rule.get('value'))
+                    rule_values.add(RuleSet.get_normalized_value(rule))
 
         filtered = list()
         t_now = time.time()

--- a/traptor/traptor.py
+++ b/traptor/traptor.py
@@ -757,6 +757,7 @@ class Traptor(object):
         if self.traptor_type == 'track':
 
             free_text = {tweet.get('text', _s),
+                         tweet.get('extended_tweet', _d).get('full_text', _s),
                          tweet.get('quoted_status', _d).get('extended_tweet', _d).get('full_text', _s),
                          tweet.get('quoted_status', _d).get('text', _s),
                          tweet.get('retweeted_status', _d).get('extended_tweet', _d).get('full_text', _s),
@@ -901,7 +902,7 @@ class Traptor(object):
                 for rule in self.redis_rules:
 
                     rule_type = rule.get('orig_type')
-                    rule_value = rule.get('value').encode("utf-8").lower()
+                    rule_value = rule.get('value').lower()
                     value_terms = rule_value.split(" ")
                     matches = list()
 

--- a/traptor/traptor.py
+++ b/traptor/traptor.py
@@ -616,21 +616,24 @@ class Traptor(object):
 
         :param tweet: the tweet rule
         """
-        rule_id = tweet.get('traptor', {}).get('rule_id', None)
+        collection_rules = tweet['traptor']['collection_rules']
 
-        # If the counter doesn't yet exist, create it
-        if self.rule_counters.get(rule_id, None) is None:
-            self.rule_counters[rule_id] = self._create_rule_counter(rule_id=rule_id)
+        for rule in collection_rules:
+            rule_id = rule.get('rule_id', None)
 
-        # If a rule value exists, increment the counter
-        try:
-            if rule_id is not None and self.rule_counters[rule_id] is not None:
-                self.rule_counters[rule_id].increment()
-        except Exception as e:
-            theLogMsg = "Caught exception while incrementing a rule counter"
-            self.logger.error(theLogMsg, extra=logExtra(e))
-            dd_monitoring.increment('redis_error',
-                                    tags=['error_type:connection_error'])
+            # If the counter doesn't yet exist, create it
+            if self.rule_counters.get(rule_id, None) is None:
+                self.rule_counters[rule_id] = self._create_rule_counter(rule_id=rule_id)
+
+            # If a rule value exists, increment the counter
+            try:
+                if rule_id is not None and self.rule_counters[rule_id] is not None:
+                    self.rule_counters[rule_id].increment()
+            except Exception as e:
+                theLogMsg = "Caught exception while incrementing a rule counter"
+                self.logger.error(theLogMsg, extra=logExtra(e))
+                dd_monitoring.increment('redis_error',
+                                        tags=['error_type:connection_error'])
 
     def _delete_rule_counters(self):
         """

--- a/traptor/traptor.py
+++ b/traptor/traptor.py
@@ -902,7 +902,7 @@ class Traptor(object):
 
                     rule_type = rule.get('orig_type')
                     rule_value = rule.get('value').encode("utf-8").lower()
-                    value_terms = rule_value.split(u" ")
+                    value_terms = rule_value.split(" ")
                     matches = list()
 
                     for search_term in value_terms:

--- a/traptor/version.py
+++ b/traptor/version.py
@@ -1,4 +1,4 @@
-__version__ = '4.0.8'
+__version__ = '4.0.7.1'
 
 if __name__ == '__main__':
     print(__version__)


### PR DESCRIPTION
# For the Reviewer
- [ ] Code review complete
- [ ] Testing Complete
- [ ] Quality ORT App Documentation Updated (your name is in the Validator square for this feature)

When this is complete, you should approve the PR via github.

# For the Reviewee

<Reminder PR Title should be JIRA_NUMBER and Useful Description>

## Summary
The updated rule matching introduced a Unicode handling error whenever a Unicode value was assigned to the Traptor, effectively handicapping the rule matching. This has downstream effects for both the rate limiting withing Traptor (we won't rate limit) and rule managers assessment of Traptor load when balancing assignments. 

This PR fixes the Unicode handling as well as broken rule volume counters stored in redis. The rate tracking now correctly handles keyword and hashtag volumes of the same value (`spacex` and `#spacex` were previously lumped together into a single token bucket). Also, we appropriately include extended tweet `full_text` which has improved rule matching to near perfection in testing. 

Because rule matching now matches all assigned rules (not simply a random single one from the set as before), the rule volume reporting in redis provides a complete picture. This should improve the rule manager decision making when it comes to assigning rules based on the volume load of each Traptor.

#### Release Note
This PR fixes the unicode handling as well as broken rule volume counters stored in redis. Also, we appropriately include extended tweet `full_text` which has improved rule matching to near perfection in testing. 

#### Breaking Changes
None.

## Quality Assurance

You have gathered the following items:
- [ ] This PR is tagged with a Release Milestone
- [ ] You have a log message clearly identifying when this feature is **working successfully**
- [ ] You have a log message clearly identifying when this feature is **failing**
- [ ] You added a PR against [p4-alerting](https://github.com/istresearch/p4-alerting/) to trigger based on the failure condition above

Given all of the items above, you have updated your Application ORT at the following locations:
- **Features and Alerting**: <link to app ORT>Required.
- **P4 Alerting**: <link to p4-alerting PR>Required.

## Testing and Verification

*Steps to test your application for someone not familiar with it.* Required.

1. Do this: `$ run-this.sh`
2. Look for this.
3. Clean up with this command
